### PR TITLE
FilesProcessor: Added processed cropVariants to JSON output

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -217,7 +217,17 @@ class FilesProcessor implements DataProcessorInterface
 
                 $data[] = $file;
             } else {
-                $data[] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+                $temporaryKey = $fileObject->getHashedIdentifier();
+                $data[$temporaryKey] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+
+                $availableCropVariants = json_decode($fileObject->getProperty('crop'), true);
+                foreach (array_keys($availableCropVariants) as $cropVariantName) {
+                    $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariantName);
+                    $data[$temporaryKey]['cropVariants'][$cropVariantName] = $file;
+                }
+
+                // reset array keys to int, starting with 0
+                $data = array_values($data);
             }
         }
 

--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -217,17 +217,21 @@ class FilesProcessor implements DataProcessorInterface
 
                 $data[] = $file;
             } else {
-                $temporaryKey = $fileObject->getHashedIdentifier();
-                $data[$temporaryKey] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+                $data[] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
 
-                $availableCropVariants = json_decode($fileObject->getProperty('crop'), true);
-                foreach (array_keys($availableCropVariants) as $cropVariantName) {
-                    $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariantName);
-                    $data[$temporaryKey]['cropVariants'][$cropVariantName] = $file;
+                $cropVariants = json_decode($fileObject->getProperty('crop'), true);
+                if (is_array($cropVariants) && count($cropVariants) > 1) {
+                    $data = [];
+                    $temporaryKey = $fileObject->getHashedIdentifier();
+                    $data[$temporaryKey] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+
+                    foreach (array_keys($cropVariants) as $cropVariantName) {
+                        $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariantName);
+                        $data[$temporaryKey]['cropVariants'][$cropVariantName] = $file;
+                    }
+
+                    $data = array_values($data);
                 }
-
-                // reset array keys to int, starting with 0
-                $data = array_values($data);
             }
         }
 


### PR DESCRIPTION
The FilesProcessor just outputs the URL to one given cropVariant (or "default") plus the crop-config array stored in $image['properties']['crop']. 
This data isn't all that useful for a frontend application though.

This PR adds a "cropVariants" Key to the processed image data, containing all rendered and processed cropVariants of a given File.

This way a frontend app can access the cropped images very easily.

Example Output:
![Bildschirmfoto 2022-02-18 um 14 38 17](https://user-images.githubusercontent.com/97380444/154693919-1465adde-1de6-4f75-9761-b7942bfd630c.png)