### PR TITLE
Add flag 'exceptionOnFailure' to format.json.decode() viewhelper for dev purposes

### DIFF
--- a/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
@@ -23,6 +23,7 @@ class DecodeViewHelper extends AbstractViewHelper
     public function initializeArguments(): void
     {
         $this->registerArgument('json', 'string', 'json to decode', false, '');
+        $this->registerArgument('exceptionOnFailure', 'boolean', 'Throw an exception when failing decoding the string', false, false);
     }
 
     /**
@@ -38,6 +39,18 @@ class DecodeViewHelper extends AbstractViewHelper
             }
         }
 
-        return json_decode($json, true);
+        $object = json_decode($json, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $object;
+        }
+
+        if ($this->arguments['exceptionOnFailure'] === true) {
+            throw new \Exception(sprintf(
+                'Failure "%s" occured when running json_decode() for string: %s',
+                json_last_error_msg(),
+                $json
+            ));
+        }
     }
 }


### PR DESCRIPTION
When running into a decoding error when applying the headless:format.json.decode() viewhelper to a string it's often not clear what's the matter. This new flag can be used to gain information on the cause of the problem.