### PR TITLE
[BUGFIX] FilesProcessor: CE with multiple images with cropVariants - only the last image is outputted

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -177,7 +177,7 @@ class FilesProcessor implements DataProcessorInterface
         $data = [];
         $cropVariant = $this->processorConfiguration['processingConfiguration.']['cropVariant'] ?? 'default';
 
-        foreach ($this->fileObjects as $fileObject) {
+        foreach ($this->fileObjects as $key => $fileObject) {
             if (isset($this->processorConfiguration['processingConfiguration.']['autogenerate.'])) {
                 $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
                 $targetWidth = (int)($dimensions['width'] ?: $file['properties']['dimensions']['width']);
@@ -217,20 +217,15 @@ class FilesProcessor implements DataProcessorInterface
 
                 $data[] = $file;
             } else {
-                $data[] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+                $data[$key] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
 
                 $cropVariants = json_decode($fileObject->getProperty('crop'), true);
-                if (is_array($cropVariants) && count($cropVariants) > 1) {
-                    $data = [];
-                    $temporaryKey = $fileObject->getHashedIdentifier();
-                    $data[$temporaryKey] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
 
+                if (is_array($cropVariants) && count($cropVariants) > 1) {
                     foreach (array_keys($cropVariants) as $cropVariantName) {
                         $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariantName);
-                        $data[$temporaryKey]['cropVariants'][$cropVariantName] = $file;
+                        $data[$key]['cropVariants'][$cropVariantName] = $file;
                     }
-
-                    $data = array_values($data);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes an error in the way the processed cropvariants are added to the individual images in the "$data" array.

**Reproducer:**
1. Choose a Content Element which processes its Files via the FilesProcessor
2. Add at least two FileReferences to that CE which have cropVariants
3. Save and view the output - only the last image is outputted

