### PR TITLE
[FEATURE] Add flag to DatabaseQueryProcessor to render only one record

### DIFF
--- a/Classes/DataProcessing/DatabaseQueryProcessor.php
+++ b/Classes/DataProcessing/DatabaseQueryProcessor.php
@@ -139,6 +139,10 @@ class DatabaseQueryProcessor implements DataProcessorInterface
                     $processedRecordVariables[$key][$fieldName] = $overrideData;
                 }
             }
+
+            if ($processorConfiguration['renderOnlyOne'] ?? false) {
+                return array_shift($processedRecordVariables);
+            }
         }
 
         return $processedRecordVariables;

--- a/Classes/DataProcessing/DatabaseQueryProcessor.php
+++ b/Classes/DataProcessing/DatabaseQueryProcessor.php
@@ -140,7 +140,7 @@ class DatabaseQueryProcessor implements DataProcessorInterface
                 }
             }
 
-            if ($processorConfiguration['renderOnlyOne'] ?? false) {
+            if ($processorConfiguration['returnFlattenObject'] ?? false) {
                 return array_shift($processedRecordVariables);
             }
         }

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -263,6 +263,40 @@ Here's an example of how you can create a JSON array of multiple objects from a 
     }
   }
 
+.. _developer-meta-override:
+
+Meta data override
+==================
+
+Here's an example of how to override the meta object by data from a DB record:
+
+.. code-block:: typoscript
+
+  lib.meta.stdWrap.override.cObject = JSON
+  lib.meta.stdWrap.override.cObject {
+    stdWrap.if.isTrue.data = GP:tx_news_pi1|news
+    dataProcessing.10 = FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor
+    dataProcessing.10 {
+      table = tx_news_domain_model_news
+      uidInList.data = GP:tx_news_pi1|news
+      uidInList.intval = 1
+      pidInList = 0
+      max = 1
+      as = records
+      fields < lib.meta.fields
+      fields {
+        title = TEXT
+        title.field = title
+        subtitle = TEXT
+        subtitle.field = teaser
+        description = TEXT
+        description.field = bodytext
+      }
+
+      renderOnlyOne = 1
+    }
+  }
+
 .. _developer-ext-form:
 
 EXT:form & form output decorators

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -293,7 +293,7 @@ Here's an example of how to override the meta object by data from a DB record:
         description.field = bodytext
       }
 
-      renderOnlyOne = 1
+      returnFlattenObject = 1
     }
   }
 


### PR DESCRIPTION
In order for this meta data override to work we had to introduce a new flag `renderOnlyOne` to `DatabaseQueryProcessor`.

Maybe there's a better solution?

```
  lib.meta.stdWrap.override.cObject = JSON
  lib.meta.stdWrap.override.cObject {
    stdWrap.if.isTrue.data = GP:tx_news_pi1|news
    dataProcessing.10 = FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor
    dataProcessing.10 {
      table = tx_news_domain_model_news
      uidInList.data = GP:tx_news_pi1|news
      uidInList.intval = 1
      pidInList = 0
      max = 1
      as = records
      fields < lib.meta.fields
      fields {
        title = TEXT
        title.field = title
        subtitle = TEXT
        subtitle.field = teaser
        description = TEXT
        description.field = bodytext
      }

      renderOnlyOne = 1
    }
  }
```

| Before | After |
| -- | -- |
| ![Bildschirmfoto vom 2022-03-18 07-23-50](https://user-images.githubusercontent.com/1405149/158948535-0867aec7-203a-4b2c-b7c2-debf69832d46.png) | ![Bildschirmfoto vom 2022-03-18 07-23-30](https://user-images.githubusercontent.com/1405149/158948536-6f241fa4-d1b5-4411-8b45-b766b8eaaef8.png) |

Related: #420