### PR TITLE
[FIX] Add fallback for undefined key "page" warning in php8

### DIFF
--- a/Classes/Service/Parser/PageJsonParser.php
+++ b/Classes/Service/Parser/PageJsonParser.php
@@ -94,7 +94,7 @@ class PageJsonParser implements JsonParserInterface
             [
                 'data' => $pageContent,
                 'tabs' => array_keys($pageContent),
-                'parsedJson' => $jsonArray[$this->getAggregatedName()],
+                'parsedJson' => $jsonArray[$this->getAggregatedName()] ?? [],
                 'contentTabName' => $this->getContentTabName(),
                 'rawTabName' => $this->getRawTabName(),
             ]


### PR DESCRIPTION
In the JsonView module `undefined key "page" warning` is thrown.