### PR TITLE
Apply stdWrap to processingConfiguration properties of FilesProcessor

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -79,12 +79,12 @@ class FilesProcessor implements DataProcessorInterface
 
         if (isset($processorConfiguration['processingConfiguration.'])) {
             $dimensions = [
-                'width' => $processorConfiguration['processingConfiguration.']['width'] ?? null,
-                'height' => $processorConfiguration['processingConfiguration.']['height'] ?? null,
-                'minWidth' => $processorConfiguration['processingConfiguration.']['minWidth'] ?? null,
-                'minHeight' => $processorConfiguration['processingConfiguration.']['minHeight'] ?? null,
-                'maxWidth' => $processorConfiguration['processingConfiguration.']['maxWidth'] ?? null,
-                'maxHeight' => $processorConfiguration['processingConfiguration.']['maxHeight'] ?? null,
+                'width' => $cObj->stdWrapValue('width', $processorConfiguration['processingConfiguration.'] ?? [], null),
+                'height' => $cObj->stdWrapValue('height', $processorConfiguration['processingConfiguration.'] ?? [], null),
+                'minWidth' => $cObj->stdWrapValue('minWidth', $processorConfiguration['processingConfiguration.'] ?? [], null),
+                'minHeight' => $cObj->stdWrapValue('minHeight', $processorConfiguration['processingConfiguration.'] ?? [], null),
+                'maxWidth' => $cObj->stdWrapValue('maxWidth', $processorConfiguration['processingConfiguration.'] ?? [], null),
+                'maxHeight' => $cObj->stdWrapValue('maxHeight', $processorConfiguration['processingConfiguration.'] ?? [], null),
             ];
         }
 


### PR DESCRIPTION
In order to be able to override and modify the properties of the processingConfiguration it'd be great to have the full power of stdWrap at hand.

This way we could modify `maxWidth` when a CE is, let's say, within a different colPos or gridelement column.