### PR TITLE
Use getTypoScriptFrontendController

### DIFF
--- a/Classes/ContentObject/JsonContentContentObject.php
+++ b/Classes/ContentObject/JsonContentContentObject.php
@@ -150,7 +150,7 @@ class JsonContentContentObject extends ContentContentObject
      */
     private function prepareValue(array $conf): array
     {
-        $frontendController = $this->getFrontendController();
+        $frontendController = $this->getTypoScriptFrontendController();
         $theValue = [];
         $originalRec = $frontendController->currentRecord;
         // If the currentRecord is set, we register, that this record has invoked this function.


### PR DESCRIPTION
The method "getFrontendController" was removed from ContentContentObject.php in TYPO3 11.5.14