### PR TITLE
Add processingConfiguration 'fileExtension' to image CEs

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -19,7 +19,22 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 use TYPO3\CMS\Frontend\Resource\FileCollector;
 
 /**
- * Class FilesProcessor
+    # Example usage:
+    10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+    10 {
+        references.fieldName = image
+        as = images
+        if.isTrue = 1
+        processingConfiguration {
+            width = <int>
+            height = <int>
+            minWidth = <int>
+            minHeight = <int>
+            maxWidth = <int>
+            maxHeight = <int>
+            fileExtension = <string>
+        }
+    }
  *
  * @codeCoverageIgnore
  */
@@ -176,10 +191,11 @@ class FilesProcessor implements DataProcessorInterface
     {
         $data = [];
         $cropVariant = $this->processorConfiguration['processingConfiguration.']['cropVariant'] ?? 'default';
+        $fileExtension = $this->processorConfiguration['processingConfiguration.']['fileExtension'] ?? null;
 
         foreach ($this->fileObjects as $key => $fileObject) {
             if (isset($this->processorConfiguration['processingConfiguration.']['autogenerate.'])) {
-                $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+                $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant, $fileExtension);
                 $targetWidth = (int)($dimensions['width'] ?: $file['properties']['dimensions']['width']);
                 $targetHeight = (int)($dimensions['height'] ?: $file['properties']['dimensions']['height']);
 
@@ -195,7 +211,8 @@ class FilesProcessor implements DataProcessorInterface
                                 'height' => $targetHeight * FileUtility::RETINA_RATIO,
                             ]
                         ),
-                        $cropVariant
+                        $cropVariant,
+                        $fileExtension
                     )['publicUrl'];
                 }
 
@@ -211,13 +228,14 @@ class FilesProcessor implements DataProcessorInterface
                                 'height' => $targetHeight * FileUtility::LQIP_RATIO,
                             ]
                         ),
-                        $cropVariant
+                        $cropVariant,
+                        $fileExtension
                     )['publicUrl'];
                 }
 
                 $data[] = $file;
             } else {
-                $data[$key] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant);
+                $data[$key] = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariant, $fileExtension);
 
                 $crop = $fileObject->getProperty('crop');
 
@@ -226,7 +244,7 @@ class FilesProcessor implements DataProcessorInterface
 
                     if (is_array($cropVariants) && count($cropVariants) > 1) {
                         foreach (array_keys($cropVariants) as $cropVariantName) {
-                            $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariantName);
+                            $file = $this->getFileUtility()->processFile($fileObject, $dimensions, $cropVariantName, $fileExtension);
                             $data[$key]['cropVariants'][$cropVariantName] = $file;
                         }
                     }

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -78,9 +78,10 @@ class FileUtility
      * @param FileInterface $fileReference
      * @param array $dimensions
      * @param string $cropVariant
+     * @param ?string $fileExtension
      * @return array
      */
-    public function processFile(FileInterface $fileReference, array $dimensions = [], string $cropVariant = 'default'): array
+    public function processFile(FileInterface $fileReference, array $dimensions = [], string $cropVariant = 'default', ?string $fileExtension = null): array
     {
         $fileReferenceUid = $fileReference->getUid();
         $uidLocal = $fileReference->getProperty('uid_local');
@@ -108,7 +109,7 @@ class FileUtility
 
         if ($fileRenderer === null && $fileReference->getType() === AbstractFile::FILETYPE_IMAGE) {
             if ($fileReference->getMimeType() !== 'image/svg+xml') {
-                $fileReference = $this->processImageFile($fileReference, $dimensions, $cropVariant);
+                $fileReference = $this->processImageFile($fileReference, $dimensions, $cropVariant, $fileExtension);
             }
             $publicUrl = $this->imageService->getImageUri($fileReference, true);
         } elseif ($fileRenderer !== null) {
@@ -150,9 +151,10 @@ class FileUtility
      * @param FileInterface $fileReference
      * @param array $dimensions
      * @param string $cropVariant
+     * @param ?string $fileExtension
      * @return ProcessedFile
      */
-    public function processImageFile(FileInterface $image, array $dimensions = [], string $cropVariant = 'default'): ProcessedFile
+    public function processImageFile(FileInterface $image, array $dimensions = [], string $cropVariant = 'default', ?string $fileExtension = null): ProcessedFile
     {
         try {
             $properties = $image->getProperties();
@@ -171,6 +173,7 @@ class FileUtility
                 'maxWidth' => $dimensions['maxWidth'] ?? $properties['maxWidth'] ?? 0,
                 'maxHeight' => $dimensions['maxHeight'] ?? $properties['maxHeight'] ?? 0,
                 'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image),
+                'fileExtension' => $fileExtension,
             ];
             return $this->imageService->applyProcessingInstructions($image, $processingInstructions);
         } catch (\UnexpectedValueException|\RuntimeException|\InvalidArgumentException $e) {


### PR DESCRIPTION
In order to be able to render webp images the image processing configuration fileExtension needs to be passed through from TS to PHP.

:exclamation: Untested port of #486 for EXT:headless 3.x :exclamation: 