### PR TITLE
elementBodyResponse in combination with doNotGroupByColPos = 1

### DIFF
--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -84,13 +84,12 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
         $body = [];
 
         foreach ($content as $items) {
+            if (!is_array($items)) {
+                continue;
+            }
             // if array is flat means doNotGroupByColPos = 1 is set
             if ((int)($items['id'] ?? 0) === $elementId) {
                 return $items;
-            }
-
-            if (!is_array($items)) {
-                continue;
             }
 
             foreach ($items as $item) {

--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -84,11 +84,11 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
         $body = [];
 
         foreach ($content as $items) {
-            // skip iteration if array is flat means doNotGroupByColPos = 1 is set
-            if(isset($items['id'])) {
-                break;
+            // if array is flat means doNotGroupByColPos = 1 is set
+            if ((int)($items['id'] ?? 0) === $elementId) {
+                return $items;
             }
-            
+
             if (!is_array($items)) {
                 continue;
             }
@@ -106,30 +106,6 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
                             if (!empty($result)) {
                                 return $result;
                             }
-                        }
-                    }
-                }
-            }
-        }
-        
-        // If no content found then its possible that option doNotGroupByColPos = 1 is set
-        // then try to find without groups of colpos
-        foreach ($content as $item) {
-            if (!is_array($item)) {
-                continue;
-            }
-
-            if ((int)($item['id'] ?? 0) === $elementId) {
-                return $item;
-            }
-
-            if ($recursiveElement && is_array($item)) {
-                foreach ($item as $prop) {
-                    if (is_array($prop)) {
-                        $result = $this->extractElement($prop, $elementId, true);
-
-                        if (!empty($result)) {
-                            return $result;
                         }
                     }
                 }

--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -84,6 +84,11 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
         $body = [];
 
         foreach ($content as $items) {
+            // skip iteration if array is flat means doNotGroupByColPos = 1 is set
+            if(isset($items['id'])) {
+                break;
+            }
+            
             if (!is_array($items)) {
                 continue;
             }

--- a/Classes/Middleware/ElementBodyResponseMiddleware.php
+++ b/Classes/Middleware/ElementBodyResponseMiddleware.php
@@ -106,6 +106,30 @@ class ElementBodyResponseMiddleware implements MiddlewareInterface
                 }
             }
         }
+        
+        // If no content found then its possible that option doNotGroupByColPos = 1 is set
+        // then try to find without groups of colpos
+        foreach ($content as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            if ((int)($item['id'] ?? 0) === $elementId) {
+                return $item;
+            }
+
+            if ($recursiveElement && is_array($item)) {
+                foreach ($item as $prop) {
+                    if (is_array($prop)) {
+                        $result = $this->extractElement($prop, $elementId, true);
+
+                        if (!empty($result)) {
+                            return $result;
+                        }
+                    }
+                }
+            }
+        }
 
         return $body;
     }

--- a/Tests/Unit/Middleware/ElementBodyResponseMiddlewareTest.php
+++ b/Tests/Unit/Middleware/ElementBodyResponseMiddlewareTest.php
@@ -142,6 +142,16 @@ class ElementBodyResponseMiddlewareTest extends UnitTestCase
         );
 
         self::assertSame(json_encode(['id' => 1]), $testResponse->getBody()->__toString());
+
+        $responseArray = ['content' => [['id' => 1]]];
+        $testJson = json_encode($responseArray);
+        $response = new HtmlResponse($testJson);
+        $testResponse = $middleware->process(
+            $this->getTestRequest(['responseElementId' => 1], 'POST'),
+            $this->getMockHandlerWithResponse($response)
+        );
+
+        self::assertSame(json_encode(['id' => 1]), $testResponse->getBody()->__toString());
     }
 
     protected function getMockHandlerWithResponse($response)


### PR DESCRIPTION
Fixed the possibility to get elementBodyResponse also if doNotGroupByColPos = 1 is set on lib.content