### PR TITLE
[BUGFIX] Fix crash when link is not resolved properly

### DIFF
--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
 
 /**
  * Class FileUtility
@@ -93,7 +94,7 @@ class FileUtility
 
         if (!empty($metaData['link'])) {
             $linkData = $this->contentObjectRenderer->typoLink('', ['parameter' => $metaData['link'], 'returnLast' => 'result']);
-            $link = $linkData->getUrl();
+            $link = $linkData instanceof LinkResultInterface ? $linkData->getUrl() : null;
         }
 
         $originalProperties = [

--- a/Tests/Unit/Utility/FileUtilityTest.php
+++ b/Tests/Unit/Utility/FileUtilityTest.php
@@ -121,6 +121,26 @@ class FileUtilityTest extends UnitTestCase
         $overwrittenBaseline['properties']['linkData'] = $linkResult;
         self::assertSame($overwrittenBaseline, $fileUtility->processFile($file));
 
+        // CASE when typolink of ContentObjectRenderer returns '' instead of LinkResult
+        $link = null;
+        $linkResult = '';
+        $file = $this->getMockFileForData($fileData, [
+            'extension' => 'jpg',
+            'title' => null,
+            'alternative' => null,
+            'description' => null,
+            'link' => 123
+        ]);
+        $processedFile = $this->getMockProcessedFileForData($fileData);
+        $imageService = $this->getImageServiceWithProcessedFile($file, $processedFile);
+        $contentObjectRenderer = $this->prophesize(ContentObjectRenderer::class);
+        $contentObjectRenderer->typoLink(Argument::any(), Argument::any())->willReturn($linkResult);
+        $fileUtility = $this->getFileUtility(null, $imageService, $contentObjectRenderer);
+        $overwrittenBaseline = $this->getBaselineResultArrayForFile();
+        $overwrittenBaseline['properties']['link'] = $link;
+        $overwrittenBaseline['properties']['linkData'] = $linkResult;
+        self::assertSame($overwrittenBaseline, $fileUtility->processFile($file));
+
         $fileReference = $this->getMockFileReferenceForData($fileReferenceData, 'video');
         $fileUtility = $this->getFileUtility();
 


### PR DESCRIPTION
Typolink method return empty string when it can not resolve link parameter