### PR TITLE
Add stdWrap functionality to FilesProcessor

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -107,6 +107,10 @@ class FilesProcessor implements DataProcessorInterface
         $fileCollector = GeneralUtility::makeInstance(FileCollector::class);
 
         if (!empty($this->processorConfiguration['references.'])) {
+            $referencesUidList = (string)$this->contentObjectRenderer->stdWrapValue('references', $this->processorConfiguration ?? []);
+            $referencesUids = GeneralUtility::intExplode(',', $referencesUidList, true);
+            $fileCollector->addFileReferences($referencesUids);
+
             $referenceConfiguration = $this->processorConfiguration['references.'];
             $relationField = $this->contentObjectRenderer->stdWrapValue('fieldName', $referenceConfiguration);
 


### PR DESCRIPTION
stdWrap functionality is missing in FilesProcessor. With this change it is possible, for example, to get files from custom fields with slide.

Example (not working without patch)

```
page {
    10 {
        fields {
            heroimage = TEXT
            heroimage {
                dataProcessing {
                    10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                    10 {
                        as = heroimage
                        references.data = levelfield: -1, heroimage, slide
                    }
                }
            }
        }
    }
}
```