### PR TITLE
[FEATURE] Add support for levelmedia images

### DIFF
--- a/Classes/DataProcessing/FilesProcessor.php
+++ b/Classes/DataProcessing/FilesProcessor.php
@@ -107,6 +107,11 @@ class FilesProcessor implements DataProcessorInterface
         $fileCollector = GeneralUtility::makeInstance(FileCollector::class);
 
         if (!empty($this->processorConfiguration['references.'])) {
+            // Support for references.data = levelmedia:-1,slide
+            $referencesUidList = (string)$this->contentObjectRenderer->stdWrapValue('references', $this->processorConfiguration ?? []);
+            $referencesUids = GeneralUtility::intExplode(',', $referencesUidList, true);
+            $fileCollector->addFileReferences($referencesUids);
+
             $referenceConfiguration = $this->processorConfiguration['references.'];
             $relationField = $this->contentObjectRenderer->stdWrapValue('fieldName', $referenceConfiguration);
 


### PR DESCRIPTION
This streamlines the headless FilesProcesser with the one from the core and allows levelmedia images:

```
page.10.fields.media.dataProcessing.10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
page.10.fields.media.dataProcessing.10 {
    as = media
    references.data = levelmedia:-1,slide
}
```

instead of:

```
page.10.fields.media.dataProcessing.10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
page.10.fields.media.dataProcessing.10 {
    as = media
    references.fieldName = media
}
```

The latter still works though.

This patch is inspired by https://forge.typo3.org/issues/78347