### PR TITLE
Add overrideFields to FlexFormProcessor

### DIFF
--- a/Classes/DataProcessing/FlexFormProcessor.php
+++ b/Classes/DataProcessing/FlexFormProcessor.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\DataProcessing;
 
 use TYPO3\CMS\Core\Service\FlexFormService;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
@@ -29,6 +30,40 @@ use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
  * 10 {
  *   fieldName = pi_flexform
  *   as = flexform
+ * }
+ *
+ * Apply TypoScript to individual fields
+ *
+ * 10 = FriendsOfTYPO3\Headless\DataProcessing\FlexFormProcessor
+ * 10 {
+ *   fieldName = pi_flexform
+ *   as = flexform
+ *   overrideFields {
+ *     image = TEXT
+ *     image {
+ *       dataProcessing {
+ *         10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
+ *         10 {
+ *           references {
+ *             table = tt_content
+ *             fieldName = image
+ *           }
+ *           as = image
+ *         }
+ *       }
+ *     }
+ *     link = TEXT
+ *     link {
+ *       field = link
+ *       htmlSpecialChars = 1
+ *       typolink {
+ *         parameter {
+ *           field = link
+ *         }
+ *         returnLast = result
+ *       }
+ *     }
+ *   }
  * }
  *
  * @codeCoverageIgnore
@@ -82,6 +117,10 @@ class FlexFormProcessor implements DataProcessorInterface
         // save result in "data" (default) or given variable name
         $targetVariableName = $cObj->stdWrapValue('as', $processorConfiguration);
 
+        if (isset($processorConfiguration['overrideFields.'])) {
+            $flexformData = $this->processOverrideFields($cObj->data, $flexformData, $processorConfiguration);
+        }
+
         if (!empty($targetVariableName)) {
             $processedData[$targetVariableName] = $flexformData;
         } else {
@@ -93,5 +132,29 @@ class FlexFormProcessor implements DataProcessorInterface
         }
 
         return $processedData;
+    }
+
+    /**
+     * @param array $data Current data-record
+     * @param array $flexformData
+     * @param array $processorConfiguration
+     * @return array
+     */
+    public function processOverrideFields(array $data, array $flexformData, array $processorConfiguration): array
+    {
+        $recordContentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $data = array_merge($data, $flexformData);
+        $recordContentObjectRenderer->start($data);
+
+        $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+        $overrideFields = $typoScriptService->convertTypoScriptArrayToPlainArray($processorConfiguration['overrideFields.']);
+        $jsonCE = $typoScriptService->convertPlainArrayToTypoScriptArray(['fields' => $overrideFields, '_typoScriptNodeValue' => 'JSON']);
+        $record = \json_decode($recordContentObjectRenderer->cObjGetSingle('JSON', $jsonCE), true);
+
+        foreach ($record as $fieldName => $overrideData) {
+            $flexformData[$fieldName] = $overrideData;
+        }
+
+        return $flexformData;
     }
 }


### PR DESCRIPTION
Configure individual fields of the FlexFormProcessor result. Same as overrideFields in DatabaseQueryProcessor, but for FlexFormProcessor (see also: https://github.com/TYPO3-Headless/headless/pull/407/commits/bf8da4789a91f1089e3ae411edec35eeb7258239). Allows to convert typolinks, images, ...


## Example

```
10 = FriendsOfTYPO3\Headless\DataProcessing\FlexFormProcessor
10 {
    fieldName = pi_flexform
    as = flexform
    overrideFields {
        image = TEXT
        image {
            dataProcessing {
                10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
                10 {
                    references {
                        table = tt_content
                        fieldName = image
                    }
                    as = image
                }
            }
        }
        link = TEXT
        link {
            field = link
            htmlSpecialChars = 1
            typolink {
                parameter {
                    field = link
                }
                returnLast = result
            }
        }
    }
}
```

### Result without overrideFields

```json
{
  "flexform": {
	"image": "1",
	"link": "t3:\/\/page?uid=13"
  }
}

```

### Result with overrideFields

```json
{
  "flexform": {
	"image": [
	  {
		"publicUrl": "http:\/\/web.domain.test\/fileadmin\/media\/testimage.png",
		"properties": {
		  "title": null,
		  "alternative": null,
		  "description": null,
		  "link": null,
		  "linkData": null,
		  "mimeType": "image\/png",
		  "type": "image",
		  "filename": "testimage.png",
		  "originalUrl": "\/fileadmin\/media\/testimage.png",
		  "uidLocal": 3370,
		  "fileReferenceUid": 9518,
		  "size": "15 KB",
		  "dimensions": {
			"width": 500,
			"height": 300
		  },
		  "cropDimensions": {
			"width": 500,
			"height": 300
		  },
		  "crop": {
			"default": {
			  "cropArea": {
				"x": 0,
				"y": 0,
				"width": 1,
				"height": 1
			  },
			  "selectedRatio": "NaN",
			  "focusArea": null
			}
		  },
		  "autoplay": null,
		  "extension": null
		}
	  }
	],
	"link": {
	  "href": "\/demo\/link",
	  "target": null,
	  "class": null,
	  "title": null,
	  "linkText": "t3:\/\/page?uid=13",
	  "additionalAttributes": []
	}
  }
}

```