### PR TITLE
[FEATURE][PoC] Introduce way to skip fluid templates

### DIFF
--- a/Classes/XClass/TemplateView.php
+++ b/Classes/XClass/TemplateView.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\XClass;
+
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
+
+use function extract;
+use function ob_end_clean;
+use function ob_get_clean;
+use function ob_start;
+
+class TemplateView extends \TYPO3\CMS\Fluid\View\TemplateView
+{
+    public function render($actionName = null)
+    {
+        if (!ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
+            return parent::render($actionName);
+        }
+
+        $renderingContext = $this->getCurrentRenderingContext();
+
+        if ((int)($renderingContext->getVariableProvider()->get('settings')['phpTemplate'] ?? 0) !== 1) {
+            return parent::render($actionName);
+        }
+
+        $templatePaths = $renderingContext->getTemplatePaths();
+        if ($actionName) {
+            $actionName = ucfirst($actionName);
+            $renderingContext->setControllerAction($actionName);
+        }
+
+        $templateFile = $templatePaths->resolveTemplateFileForControllerAndActionAndFormat($renderingContext->getControllerName(), $renderingContext->getControllerAction(), 'php');
+
+        if ($templateFile === null) {
+            throw new InvalidTemplateResourceException('Template is not found');
+        }
+
+        return $this->loadTemplate($templateFile, $renderingContext);
+    }
+
+    private function loadTemplate(string $templateFile, RenderingContextInterface $renderingContext): string
+    {
+        $__jsonContent = '';
+
+        try {
+            extract($renderingContext->getVariableProvider()->getAll());
+
+            ob_start();
+            include $templateFile;
+            $__jsonContent = ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+
+        return $__jsonContent;
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -12,6 +12,8 @@ use FriendsOfTYPO3\Headless\Seo\XmlSitemap\XmlSitemapRenderer;
 use FriendsOfTYPO3\Headless\Utility\HeadlessFrontendUrlInterface;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Core\Configuration\Features;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Form\Controller\FormFrontendController;
 use TYPO3\CMS\FrontendLogin\Controller\LoginController;
 
@@ -44,4 +46,10 @@ return static function (ContainerConfigurator $configurator): void {
 
     $services->set(HeadlessFrontendUrlInterface::class, UrlUtility::class)->autowire(false);
     $services->set(XmlSitemapRenderer::class)->public()->share(false);
+
+    $features = GeneralUtility::makeInstance(Features::class);
+
+    if ($features->isFeatureEnabled('headless.overrideFluidTemplates')) {
+        $services->alias(\TYPO3\CMS\Fluid\View\TemplateView::class, \FriendsOfTYPO3\Headless\XClass\TemplateView::class);
+    }
 };

--- a/Tests/Unit/XClass/Fixtures/Templates/Default/Default.php
+++ b/Tests/Unit/XClass/Fixtures/Templates/Default/Default.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+echo json_encode([
+    'testKey' => $testValue,
+]);

--- a/Tests/Unit/XClass/TemplateViewTest.php
+++ b/Tests/Unit/XClass/TemplateViewTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\XClass;
+
+use FriendsOfTYPO3\Headless\XClass\TemplateView;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
+use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperResolver;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
+use TYPO3Fluid\Fluid\View\TemplatePaths;
+
+use function json_encode;
+
+class TemplateViewTest extends UnitTestCase
+{
+    public function testTemplateNotFoundOrPHPTemplatesDisabledRender(): void
+    {
+        $this->expectException(InvalidTemplateResourceException::class);
+
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1); // fe request
+
+        $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
+
+        $variableProvider = new StandardVariableProvider();
+        $variableProvider->add('settings', ['phpTemplate' => 1]);
+
+        $context->setVariableProvider($variableProvider);
+        $view = new TemplateView($context);
+        $view->render();
+
+        $variableProvider = new StandardVariableProvider();
+        $variableProvider->add('settings', ['phpTemplate' => 0]);
+
+        $context->setVariableProvider($variableProvider);
+        $view = new TemplateView($context);
+        $view->render();
+    }
+
+    public function testTemplateRender(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())->withAttribute('applicationType', 1); // fe request
+
+        $context = new RenderingContext($this->createMock(ViewHelperResolver::class), $this->createMock(FluidCacheInterface::class), [], []);
+
+        $variableProvider = new StandardVariableProvider();
+        $variableProvider->add('settings', ['phpTemplate' => 1]);
+        $variableProvider->add('testValue', 'TestingJsonValue');
+
+        $context->setVariableProvider($variableProvider);
+
+        $templatePaths = $this->createMock(TemplatePaths::class);
+        $templatePaths->method('resolveTemplateFileForControllerAndActionAndFormat')->willReturn(__DIR__ . '/Fixtures/Templates/Default/Default.php');
+
+        $context->setTemplatePaths($templatePaths);
+
+        $view = new TemplateView($context);
+
+        self::assertSame(json_encode(['testKey' => 'TestingJsonValue']), $view->render());
+    }
+}


### PR DESCRIPTION
resolves: #184

Feature if enabled replaces rendering templates in fluid in frontend context with php templates in order to simplify output json.

 Templates paths resolving is the same as in fluid, feature seeks just files with php extension,

 In php template you should just echo json_encode([...]);

How to enable:

- add new `headless.overrideFluidTemplates` flag to LocalConfiguration
- add to typoscript settings for desired plugin, flag `phpTemplate`=1 in order to override fluid templates