### PR TITLE
v12 fixes part3

### DIFF
--- a/Tests/Functional/ContentTypes/MenuAbstractPagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuAbstractPagesElementTest.php
@@ -37,12 +37,11 @@ class MenuAbstractPagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']['menu'][0]);
         self::assertIsArray($contentElement['content']['menu'][0]['media']);
 
-        // regression in core
-//        self::assertEquals('Page 4', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page4', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//        self::assertEquals('Test', $contentElement['content']['menu'][0]['abstract']);
+        self::assertEquals('Page 4', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page4', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+        self::assertEquals('Test', $contentElement['content']['menu'][0]['abstract']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuCategorizedPagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuCategorizedPagesElementTest.php
@@ -37,11 +37,10 @@ class MenuCategorizedPagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']['menu'][0]);
         self::assertIsArray($contentElement['content']['menu'][0]['media']);
 
-        // regression in core
-//        self::assertEquals('Page 3', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page3', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+        self::assertEquals('Page 3', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page3', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuPagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuPagesElementTest.php
@@ -35,32 +35,32 @@ class MenuPagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']);
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][1]);
-//        self::assertIsArray($contentElement['content']['menu'][2]);
-//        self::assertIsArray($contentElement['content']['menu'][3]);
-//
-//        self::assertEquals('Root', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('1', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('1', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//
-//        self::assertEquals('Page 1', $contentElement['content']['menu'][1]['title']);
-//        self::assertEquals('/page1', $contentElement['content']['menu'][1]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
-//
-//        self::assertEquals('Page 1.1', $contentElement['content']['menu'][2]['title']);
-//        self::assertEquals('/page1/page1_1', $contentElement['content']['menu'][2]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][2]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][2]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][2]['spacer']);
-//
-//        self::assertEquals('Page 2', $contentElement['content']['menu'][3]['title']);
-//        self::assertEquals('/page2', $contentElement['content']['menu'][3]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][3]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][3]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][3]['spacer']);
+        self::assertIsArray($contentElement['content']['menu'][1]);
+        self::assertIsArray($contentElement['content']['menu'][2]);
+        self::assertIsArray($contentElement['content']['menu'][3]);
+
+        self::assertEquals('Root', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('1', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('1', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+
+        self::assertEquals('Page 1', $contentElement['content']['menu'][1]['title']);
+        self::assertEquals('/page1', $contentElement['content']['menu'][1]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
+
+        self::assertEquals('Page 1.1', $contentElement['content']['menu'][2]['title']);
+        self::assertEquals('/page1/page1_1', $contentElement['content']['menu'][2]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][2]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][2]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][2]['spacer']);
+
+        self::assertEquals('Page 2', $contentElement['content']['menu'][3]['title']);
+        self::assertEquals('/page2', $contentElement['content']['menu'][3]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][3]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][3]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][3]['spacer']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuRecentlyUpdatedPagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuRecentlyUpdatedPagesElementTest.php
@@ -51,22 +51,22 @@ class MenuRecentlyUpdatedPagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']);
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][1]);
-//
-//        self::assertEquals('Page 1', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page1', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//        self::assertIsArray($contentElement['content']['menu'][0]['media']);
-//
-//        self::assertEquals('Page 1.1', $contentElement['content']['menu'][1]['title']);
-//        self::assertEquals('/page1/page1_1', $contentElement['content']['menu'][1]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
-//        self::assertIsArray($contentElement['content']['menu'][1]['media']);
-//
-//        self::assertArrayNotHasKey(2, $contentElement['content']['menu']);
+        self::assertIsArray($contentElement['content']['menu'][1]);
+
+        self::assertEquals('Page 1', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page1', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+        self::assertIsArray($contentElement['content']['menu'][0]['media']);
+
+        self::assertEquals('Page 1.1', $contentElement['content']['menu'][1]['title']);
+        self::assertEquals('/page1/page1_1', $contentElement['content']['menu'][1]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
+        self::assertIsArray($contentElement['content']['menu'][1]['media']);
+
+        self::assertArrayNotHasKey(2, $contentElement['content']['menu']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuRelatedPagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuRelatedPagesElementTest.php
@@ -35,33 +35,33 @@ class MenuRelatedPagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']);
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][1]);
-//
-//        self::assertEquals('Page 10', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page10', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][0]['media']);
-//        self::assertEmpty($contentElement['content']['menu'][0]['media']);
-//
-//        self::assertEquals('Page 8', $contentElement['content']['menu'][1]['title']);
-//        self::assertEquals('/page8', $contentElement['content']['menu'][1]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
-//        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][1]);
-//        self::assertIsArray($contentElement['content']['menu'][1]['media']);
-//        self::assertEmpty($contentElement['content']['menu'][1]['media']);
-//
-//        self::assertEquals('Page 9', $contentElement['content']['menu'][2]['title']);
-//        self::assertEquals('/page9', $contentElement['content']['menu'][2]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][2]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][2]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][2]['spacer']);
-//        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][2]);
-//        self::assertIsArray($contentElement['content']['menu'][2]['media']);
-//        self::assertEmpty($contentElement['content']['menu'][2]['media']);
+        self::assertIsArray($contentElement['content']['menu'][1]);
+
+        self::assertEquals('Page 10', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page10', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][0]);
+        self::assertIsArray($contentElement['content']['menu'][0]['media']);
+        self::assertEmpty($contentElement['content']['menu'][0]['media']);
+
+        self::assertEquals('Page 8', $contentElement['content']['menu'][1]['title']);
+        self::assertEquals('/page8', $contentElement['content']['menu'][1]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
+        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][1]);
+        self::assertIsArray($contentElement['content']['menu'][1]['media']);
+        self::assertEmpty($contentElement['content']['menu'][1]['media']);
+
+        self::assertEquals('Page 9', $contentElement['content']['menu'][2]['title']);
+        self::assertEquals('/page9', $contentElement['content']['menu'][2]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][2]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][2]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][2]['spacer']);
+        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][2]);
+        self::assertIsArray($contentElement['content']['menu'][2]['media']);
+        self::assertEmpty($contentElement['content']['menu'][2]['media']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuSectionElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuSectionElementTest.php
@@ -31,7 +31,7 @@ class MenuSectionElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']);
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][1]);
+        self::assertIsArray($contentElement['content']['menu'][1]);
 
         self::assertEquals('Root', $contentElement['content']['menu'][0]['title']);
         self::assertEquals('/', $contentElement['content']['menu'][0]['link']);
@@ -41,12 +41,12 @@ class MenuSectionElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']['menu'][0]['media']);
         self::assertIsArray($contentElement['content']['menu'][0]['content']);
 
-//        self::assertEquals('Page 2', $contentElement['content']['menu'][1]['title']);
-//        self::assertEquals('/page2', $contentElement['content']['menu'][1]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
-//        self::assertIsArray($contentElement['content']['menu'][1]['media']);
-//        self::assertIsArray($contentElement['content']['menu'][1]['content']);
+        self::assertEquals('Page 2', $contentElement['content']['menu'][1]['title']);
+        self::assertEquals('/page2', $contentElement['content']['menu'][1]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
+        self::assertIsArray($contentElement['content']['menu'][1]['media']);
+        self::assertIsArray($contentElement['content']['menu'][1]['content']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuSitemapElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuSitemapElementTest.php
@@ -35,34 +35,34 @@ class MenuSitemapElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']);
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][1]);
-//
-//        self::assertEquals('Page 1', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page1', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//        self::assertArrayHasKey('children', $contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][0]['children']);
-//        self::assertIsArray($contentElement['content']['menu'][0]['images']);
-//        self::assertEmpty($contentElement['content']['menu'][0]['images']);
-//
-//        self::assertEquals('Page 2', $contentElement['content']['menu'][1]['title']);
-//        self::assertEquals('/page2', $contentElement['content']['menu'][1]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
-//        self::assertIsArray($contentElement['content']['menu'][1]['images']);
-//        self::assertEmpty($contentElement['content']['menu'][1]['images']);
-//        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][1]);
-//
-//        self::assertEquals('Page 1.1', $contentElement['content']['menu'][0]['children'][0]['title']);
-//        self::assertEquals('/page1/page1_1', $contentElement['content']['menu'][0]['children'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['spacer']);
-//        self::assertIsArray($contentElement['content']['menu'][0]['children'][0]['images']);
-//        self::assertEmpty($contentElement['content']['menu'][0]['children'][0]['images']);
-//        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][0]['children'][0]);
+        self::assertIsArray($contentElement['content']['menu'][1]);
+
+        self::assertEquals('Page 1', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page1', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+        self::assertArrayHasKey('children', $contentElement['content']['menu'][0]);
+        self::assertIsArray($contentElement['content']['menu'][0]['children']);
+        self::assertIsArray($contentElement['content']['menu'][0]['images']);
+        self::assertEmpty($contentElement['content']['menu'][0]['images']);
+
+        self::assertEquals('Page 2', $contentElement['content']['menu'][1]['title']);
+        self::assertEquals('/page2', $contentElement['content']['menu'][1]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
+        self::assertIsArray($contentElement['content']['menu'][1]['images']);
+        self::assertEmpty($contentElement['content']['menu'][1]['images']);
+        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][1]);
+
+        self::assertEquals('Page 1.1', $contentElement['content']['menu'][0]['children'][0]['title']);
+        self::assertEquals('/page1/page1_1', $contentElement['content']['menu'][0]['children'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['spacer']);
+        self::assertIsArray($contentElement['content']['menu'][0]['children'][0]['images']);
+        self::assertEmpty($contentElement['content']['menu'][0]['children'][0]['images']);
+        self::assertArrayNotHasKey('children', $contentElement['content']['menu'][0]['children'][0]);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuSitemapSelectedPagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuSitemapSelectedPagesElementTest.php
@@ -36,20 +36,20 @@ class MenuSitemapSelectedPagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
 
-//        self::assertEquals('Page 4', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page4', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//        self::assertArrayHasKey('children', $contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][0]['children']);
-//        self::assertIsArray($contentElement['content']['menu'][0]['images']);
-//        self::assertEmpty($contentElement['content']['menu'][0]['images']);
-//        self::assertEquals('Page 5', $contentElement['content']['menu'][0]['children'][0]['title']);
-//        self::assertEquals('/page5', $contentElement['content']['menu'][0]['children'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['spacer']);
-//        self::assertEmpty($contentElement['content']['menu'][0]['children'][0]['images']);
+        self::assertEquals('Page 4', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page4', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+        self::assertArrayHasKey('children', $contentElement['content']['menu'][0]);
+        self::assertIsArray($contentElement['content']['menu'][0]['children']);
+        self::assertIsArray($contentElement['content']['menu'][0]['images']);
+        self::assertEmpty($contentElement['content']['menu'][0]['images']);
+        self::assertEquals('Page 5', $contentElement['content']['menu'][0]['children'][0]['title']);
+        self::assertEquals('/page5', $contentElement['content']['menu'][0]['children'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['children'][0]['spacer']);
+        self::assertEmpty($contentElement['content']['menu'][0]['children'][0]['images']);
     }
 }

--- a/Tests/Functional/ContentTypes/MenuSubpagesElementTest.php
+++ b/Tests/Functional/ContentTypes/MenuSubpagesElementTest.php
@@ -35,18 +35,18 @@ class MenuSubpagesElementTest extends BaseContentTypeTest
         self::assertIsArray($contentElement['content']);
         self::assertIsArray($contentElement['content']['menu']);
         self::assertIsArray($contentElement['content']['menu'][0]);
-//        self::assertIsArray($contentElement['content']['menu'][1]);
+        self::assertIsArray($contentElement['content']['menu'][1]);
 
-//        self::assertEquals('Page 1', $contentElement['content']['menu'][0]['title']);
-//        self::assertEquals('/page1', $contentElement['content']['menu'][0]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
-//
-//        self::assertEquals('Page 2', $contentElement['content']['menu'][1]['title']);
-//        self::assertEquals('/page2', $contentElement['content']['menu'][1]['link']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
-//        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
+        self::assertEquals('Page 1', $contentElement['content']['menu'][0]['title']);
+        self::assertEquals('/page1', $contentElement['content']['menu'][0]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][0]['spacer']);
+
+        self::assertEquals('Page 2', $contentElement['content']['menu'][1]['title']);
+        self::assertEquals('/page2', $contentElement['content']['menu'][1]['link']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['active']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['current']);
+        self::assertEquals('0', $contentElement['content']['menu'][1]['spacer']);
     }
 }


### PR DESCRIPTION
- [BUGFIX] Properly configure headless ContentObjects/DataProcessors
- [FEATURE] Allow to use tagged alis for processor i.e. "headless-menu" instead of full class name
- Restored functional tests