### PR TITLE
[TASK] Cleanup composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   ],
   "require": {
     "ext-json": "*",
-    "typo3/cms-core": "^12.1",
-    "typo3/cms-install": "^12.1"
+    "typo3/cms-core": "^12.4",
+    "typo3/cms-install": "^12.4"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.15.0",
@@ -42,11 +42,10 @@
     "phpstan/phpstan": "^1.9",
     "phpunit/phpcov": "^8.2",
     "saschaegerer/phpstan-typo3": "^1.1",
-    "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
     "seld/jsonlint": "^1.8",
     "symfony/yaml": "^6.1",
-    "typo3/cms-form": "12.*@dev",
-    "typo3/testing-framework": "^7.0@dev"
+    "typo3/cms-form": "^12.4",
+    "typo3/testing-framework": "^7.0"
   },
   "config": {
     "preferred-install": {
@@ -57,10 +56,8 @@
     "allow-plugins": {
       "typo3/class-alias-loader": true,
       "typo3/cms-composer-installers": true,
-      "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true,
       "ergebnis/composer-normalize": true,
-      "phpstan/extension-installer": true,
-      "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true
+      "phpstan/extension-installer": true
     }
   },
   "extra": {


### PR DESCRIPTION
- Lock typo3/testing-framework to version ^7
- Remove sbuerk/typo3-cmscomposerinstallers-testingframework-bridge
- Set minimum version of TYPO3 to 12.4