### PR TITLE
Fixed error when sending forms (FormController fix for v12)

### DIFF
--- a/Classes/XClass/Controller/FormFrontendController.php
+++ b/Classes/XClass/Controller/FormFrontendController.php
@@ -208,7 +208,9 @@ class FormFrontendController extends \TYPO3\CMS\Form\Controller\FormFrontendCont
         if ($formState &&
             $formState->isFormSubmitted() &&
             $this->request->getMethod() === 'POST') {
-            $result = $formRuntime->getRequest()->getOriginalRequestMappingResults();
+            /** @var ExtbaseRequestParameters $extbaseRequestParameters */
+            $extbaseRequestParameters = $formRuntime->getRequest()->getAttribute('extbase');
+            $result = $extbaseRequestParameters->getOriginalRequestMappingResults();
             /**
              * @var array<string, Error[]>
              */


### PR DESCRIPTION
Fixes the following error after submitting a form:

```
Call to undefined method TYPO3\CMS\Extbase\Mvc\Request::getOriginalRequestMappingResults() 
in /var/www/html/vendor/friendsoftypo3/headless/Classes/XClass/Controller/FormFrontendController.php line 211
```