### PR TITLE
[FEATURE] Allow non cachable plugins to return null on empty

### DIFF
--- a/Classes/ContentObject/JsonContentContentObject.php
+++ b/Classes/ContentObject/JsonContentContentObject.php
@@ -23,7 +23,6 @@ use function count;
 use function is_array;
 use function json_decode;
 use function str_contains;
-use function strpos;
 use function trim;
 
 use const JSON_FORCE_OBJECT;
@@ -128,8 +127,7 @@ class JsonContentContentObject extends ContentContentObject
                 continue;
             }
 
-            if (strpos($element, '<!--INT_SCRIPT') !== false
-                && strpos($element, HeadlessUserInt::STANDARD) === false) {
+            if (str_contains($element, '<!--INT_SCRIPT') && !str_contains($element, HeadlessUserInt::STANDARD)) {
                 $element = $this->headlessUserInt->wrap($element);
             }
 

--- a/Classes/ContentObject/JsonContentObject.php
+++ b/Classes/ContentObject/JsonContentObject.php
@@ -112,7 +112,7 @@ class JsonContentObject extends AbstractContentObject implements LoggerAwareInte
                     $content[$theKey] = (bool)(int)$content[$theKey];
                 }
                 if ($theValue === 'USER_INT' || strpos((string)$content[$theKey], '<!--INT_SCRIPT.') === 0) {
-                    $content[$theKey] = $this->headlessUserInt->wrap($content[$theKey]);
+                    $content[$theKey] = $this->headlessUserInt->wrap($content[$theKey], (int)($conf['ifEmptyReturnNull'] ?? 0) === 1 ? HeadlessUserInt::STANDARD_NULLABLE : HeadlessUserInt::STANDARD);
                 }
                 if ((int)($conf['ifEmptyReturnNull'] ?? 0) === 1 && $content[$theKey] === '') {
                     $content[$theKey] = null;

--- a/Tests/Unit/Hooks/HeadlessUserIntTest.php
+++ b/Tests/Unit/Hooks/HeadlessUserIntTest.php
@@ -17,6 +17,8 @@ use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
+use function json_encode;
+
 class HeadlessUserIntTest extends UnitTestCase
 {
     use ProphecyTrait;
@@ -127,6 +129,56 @@ class HeadlessUserIntTest extends UnitTestCase
         $tsfe->content = $classUnderTest->unwrap($tsfe->content);
 
         self::assertEquals($testProcessed, $tsfe->content);
+    }
+
+    /**
+     * @test
+     */
+    public function processingEmptyPluginResponse()
+    {
+        $testProcessed = json_encode(
+            ''
+        );
+        $testContent = '"HEADLESS_INT_NULL_START<<' . $testProcessed . '>>HEADLESS_INT_NULL_END"';
+
+        $setup = [];
+        $setup['plugin.']['tx_headless.']['staticTemplate'] = '1';
+
+        $tmpl = $this->prophesize(TemplateService::class);
+        $tmpl->setup = $setup;
+
+        $tsfe = $this->prophesize(TypoScriptFrontendController::class);
+        $tsfe->tmpl = $tmpl->reveal();
+
+        $tsfe->content = $testContent;
+
+        $classUnderTest = new HeadlessUserInt();
+
+        $tsfe->content = $classUnderTest->unwrap($tsfe->content);
+
+        self::assertEquals(json_encode(null), $tsfe->content);
+
+        $testProcessed = json_encode(
+            ''
+        );
+        $testContent = '"NESTED_HEADLESS_INT_NULL_START<<' . $testProcessed . '>>NESTED_HEADLESS_INT_NULL_END"';
+
+        $setup = [];
+        $setup['plugin.']['tx_headless.']['staticTemplate'] = '1';
+
+        $tmpl = $this->prophesize(TemplateService::class);
+        $tmpl->setup = $setup;
+
+        $tsfe = $this->prophesize(TypoScriptFrontendController::class);
+        $tsfe->tmpl = $tmpl->reveal();
+
+        $tsfe->content = $testContent;
+
+        $classUnderTest = new HeadlessUserInt();
+
+        $tsfe->content = $classUnderTest->unwrap($tsfe->content);
+
+        self::assertEquals(json_encode(null), $tsfe->content);
     }
 
     /**


### PR DESCRIPTION
Handles cases when plugin marked as USER_INT wants to in some case do not return some data, by default instead of empty string, we want set null for better type system in FE app