### PR TITLE
[FEATURE] Move hardcoded labels to xlf files to support translation via crowdin (#545)

### DIFF
--- a/Classes/DataProcessing/GalleryProcessor.php
+++ b/Classes/DataProcessing/GalleryProcessor.php
@@ -109,7 +109,7 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
             // Recalculate gallery width
             $this->galleryData['width'] = floor($maximumRowWidth / $mediaScalingCorrection);
 
-        // User entered a predefined width
+            // User entered a predefined width
         } elseif ($this->equalMediaWidth) {
             $mediaScalingCorrection = 1;
 
@@ -133,7 +133,7 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
             // Recalculate gallery width
             $this->galleryData['width'] = floor($totalRowWidth / $mediaScalingCorrection);
 
-        // Automatic setting of width and height
+            // Automatic setting of width and height
         } else {
             $maxMediaWidth = (int)($galleryWidthMinusBorderAndSpacing / $this->galleryData['count']['columns']);
             foreach ($this->fileObjects as $key => $fileObject) {

--- a/Configuration/SiteConfiguration/Overrides/site.php
+++ b/Configuration/SiteConfiguration/Overrides/site.php
@@ -14,8 +14,8 @@ $features = GeneralUtility::makeInstance(Features::class);
 
 $tempColumns = [
     'frontendBase' => [
-        'label' => 'Frontend Entry Point',
-        'description' => 'Main URL to call the frontend in default language.',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.frontendBase.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.frontendBase.description',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -28,8 +28,8 @@ $replaceShowItem = 'base, frontendBase, ';
 
 if ($features->isFeatureEnabled('headless.storageProxy')) {
     $tempColumns['frontendApiProxy'] = [
-        'label' => 'Frontend API proxy url',
-        'description' => 'Main URL to for proxy API',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.frontendApiProxy.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.frontendApiProxy.description',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -38,8 +38,8 @@ if ($features->isFeatureEnabled('headless.storageProxy')) {
     ];
 
     $tempColumns['frontendFileApi'] = [
-        'label' => 'Frontend API proxy url for files',
-        'description' => 'Main URL to for proxy API files',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.frontendFileApi.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.frontendFileApi.description',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -52,7 +52,7 @@ if ($features->isFeatureEnabled('headless.storageProxy')) {
 
 if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
     $tempColumns['cookieDomain'] = [
-        'label' => 'Cookie Domain',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.cookieDomain.label',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -63,8 +63,8 @@ if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
     $replaceShowItem .= 'cookieDomain,';
 }
 
-$GLOBALS['SiteConfiguration']['site']['columns']['base']['label'] = 'TYPO3 Entry Point';
-$GLOBALS['SiteConfiguration']['site']['columns']['base']['description'] = 'Main URL to call the TYPO3 headless api in default language.';
+$GLOBALS['SiteConfiguration']['site']['columns']['base']['label'] = 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.base.label';
+$GLOBALS['SiteConfiguration']['site']['columns']['base']['description'] = 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.base.description';
 
 $GLOBALS['SiteConfiguration']['site']['columns'] = array_merge(
     $GLOBALS['SiteConfiguration']['site']['columns'],

--- a/Configuration/SiteConfiguration/Overrides/site_base_variant.php
+++ b/Configuration/SiteConfiguration/Overrides/site_base_variant.php
@@ -14,8 +14,8 @@ $features = GeneralUtility::makeInstance(Features::class);
 
 $tempColumns = [
     'frontendBase' => [
-        'label' => 'Frontend Entry Point',
-        'description' => 'For example "https://front.staging.domain.tld" or "http://front.domain.local"',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.frontendBase.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.frontendBase.description',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -28,8 +28,8 @@ $replaceShowItem = 'base, frontendBase, ';
 
 if ($features->isFeatureEnabled('headless.storageProxy')) {
     $tempColumns['frontendApiProxy'] = [
-        'label' => 'Frontend API proxy url',
-        'description' => 'Main URL to for proxy API',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.frontendApiProxy.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.frontendApiProxy.description',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -38,8 +38,8 @@ if ($features->isFeatureEnabled('headless.storageProxy')) {
     ];
 
     $tempColumns['frontendFileApi'] = [
-        'label' => 'Frontend API proxy url for files',
-        'description' => 'Main URL to for proxy API files',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.frontendFileApi.label',
+        'description' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.frontendFileApi.description',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -52,7 +52,7 @@ if ($features->isFeatureEnabled('headless.storageProxy')) {
 
 if ($features->isFeatureEnabled('headless.cookieDomainPerSite')) {
     $tempColumns['cookieDomain'] = [
-        'label' => 'Cookie Domain',
+        'label' => 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:siteBaseVariant.columns.cookieDomain.label',
         'config' => [
             'type' => 'input',
             'eval' => 'trim',
@@ -67,7 +67,7 @@ $GLOBALS['SiteConfiguration']['site_base_variant']['columns'] = array_merge(
     $GLOBALS['SiteConfiguration']['site_base_variant']['columns'],
     $tempColumns
 );
-$GLOBALS['SiteConfiguration']['site_base_variant']['columns']['base']['label'] = 'TYPO3 Entry Point';
+$GLOBALS['SiteConfiguration']['site_base_variant']['columns']['base']['label'] = 'LLL:EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf:site.columns.base.label';
 
 $GLOBALS['SiteConfiguration']['site_base_variant']['types']['1']['showitem'] = str_replace(
     'base,',

--- a/Resources/Private/Language/locallang_siteconfiguration.xlf
+++ b/Resources/Private/Language/locallang_siteconfiguration.xlf
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en"
+          datatype="plaintext"
+          original="EXT:headless/Resources/Private/Language/locallang_siteconfiguration.xlf"
+          date="2023-05-25T10:00:00Z"
+          product-name="headless">
+        <header/>
+        <body>
+            <trans-unit id="site.columns.base.label" resname="site.columns.base.label">
+                <source>TYPO3 Entry Point</source>
+            </trans-unit>
+            <trans-unit id="site.columns.base.description" resname="site.columns.base.description">
+                <source>Main URL to call the TYPO3 headless api in default language.</source>
+            </trans-unit>
+            <trans-unit id="site.columns.cookieDomain.label" resname="site.columns.cookieDomain.label">
+                <source>Cookie Domain</source>
+            </trans-unit>
+            <trans-unit id="site.columns.frontendApiProxy.label" resname="site.columns.frontendApiProxy.label">
+                <source>Frontend API proxy url</source>
+            </trans-unit>
+            <trans-unit id="site.columns.frontendApiProxy.description" resname="site.columns.frontendApiProxy.description">
+                <source>Main URL to for proxy API</source>
+            </trans-unit>
+            <trans-unit id="site.columns.frontendBase.label" resname="site.columns.frontendBase.label">
+                <source>Frontend Entry Point</source>
+            </trans-unit>
+            <trans-unit id="site.columns.frontendBase.description" resname="site.columns.frontendBase.description">
+                <source>Main URL to call the frontend in default language.</source>
+            </trans-unit>
+            <trans-unit id="site.columns.frontendFileApi.label" resname="site.columns.frontendFileApi.label">
+                <source>Frontend API proxy url for files</source>
+            </trans-unit>
+            <trans-unit id="site.columns.frontendFileApi.description" resname="site.columns.frontendFileApi.description">
+                <source>Main URL to for proxy API files</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.cookieDomain.label" resname="siteBaseVariant.columns.cookieDomain.label">
+                <source>Cookie Domain</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.frontendApiProxy.label" resname="siteBaseVariant.columns.frontendApiProxy.label">
+                <source>Frontend API proxy url</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.frontendApiProxy.description" resname="siteBaseVariant.columns.frontendApiProxy.description">
+                <source>Main URL to for proxy API</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.frontendBase.label" resname="siteBaseVariant.columns.frontendBase.label">
+                <source>Frontend Entry Point</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.frontendBase.description" resname="siteBaseVariant.columns.frontendBase.description">
+                <source>For example "https://front.staging.domain.tld" or "http://front.domain.local"</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.frontendFileApi.label" resname="siteBaseVariant.columns.frontendFileApi.label">
+                <source>Frontend API proxy url for files</source>
+            </trans-unit>
+            <trans-unit id="siteBaseVariant.columns.frontendFileApi.description" resname="siteBaseVariant.columns.frontendFileApi.description">
+                <source>Main URL to for proxy API files</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
This changes moves the hardcoded labels into a xlf file (in this case for labels inside "./Configuration/SiteConfiguration/"):

- Add xlf file for translating the site configuration
- Replace hardcoded labels with the labels from the translation file

Related: #545
Resolves: #545