### PR TITLE
[BUGFIX] Trim whitespaces in JSON decode helper

### DIFF
--- a/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
@@ -33,6 +33,9 @@ class DecodeViewHelper extends AbstractViewHelper
         $json = $this->arguments['json'];
         if ($json === null) {
             $json = $this->renderChildren();
+            if ($json !== null) {
+                $json = trim($json);
+            }
             if (empty($json)) {
                 return null;
             }

--- a/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\ViewHelpers\Format\Json;
+
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+use FriendsOfTYPO3\Headless\ViewHelpers\Format\Json\DecodeViewHelper;
+
+class DecodeViewHelperTest extends UnitTestCase
+{
+    public function testRender(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = true;
+        $decodeViewHelper = new DecodeViewHelper();
+        $decodeViewHelper->setArguments(['json' => null]);
+        $decodeViewHelper->setRenderChildrenClosure(function() { return "\n \n"; } );
+        $result = $decodeViewHelper->render();
+        self::assertSame(null, $result);
+    }
+}

--- a/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\Tests\Unit\ViewHelpers\Format\Json;
 
-use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 use FriendsOfTYPO3\Headless\ViewHelpers\Format\Json\DecodeViewHelper;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 class DecodeViewHelperTest extends UnitTestCase
 {
@@ -21,8 +21,8 @@ class DecodeViewHelperTest extends UnitTestCase
         $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = true;
         $decodeViewHelper = new DecodeViewHelper();
         $decodeViewHelper->setArguments(['json' => null]);
-        $decodeViewHelper->setRenderChildrenClosure(function() { return "\n \n"; } );
+        $decodeViewHelper->setRenderChildrenClosure(function () { return "\n \n"; });
         $result = $decodeViewHelper->render();
-        self::assertSame(null, $result);
+        self::assertNull($result);
     }
 }


### PR DESCRIPTION
Adding trim() fixed the error when there was a space in the passed value along with one of the characters: \n \r \t \v \x00