### PR TITLE
[BUGFIX] Fix missing property in FileUtility

### DIFF
--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -37,6 +37,7 @@ class FileUtility
     protected ImageService  $imageService;
     protected ?ServerRequestInterface $serverRequest;
     protected EventDispatcherInterface $eventDispatcher;
+    protected Features $features;
 
     /**
      * @var array<string, array<string, string>>


### PR DESCRIPTION
Fixes the following alert:

```
[ALERT] request="b5fa28bd5dc9b" component="TYPO3.CMS.Frontend.ContentObject.Exception.ProductionExceptionHandler": Oops, an error occurred! Code: 20230620052916f6fe734f- Exception: PHP Runtime Deprecation Notice: Creation of dynamic property FriendsOfTYPO3\Headless\Utility\FileUtility::$features is deprecated in /var/www/html/vendor/friendsoftypo3/headless/Classes/Utility/FileUtility.php line 60
```

