### PR TITLE
Add option for GalleryProcessor: fileExtension

### DIFF
--- a/Classes/DataProcessing/GalleryProcessor.php
+++ b/Classes/DataProcessing/GalleryProcessor.php
@@ -109,7 +109,7 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
             // Recalculate gallery width
             $this->galleryData['width'] = floor($maximumRowWidth / $mediaScalingCorrection);
 
-            // User entered a predefined width
+        // User entered a predefined width
         } elseif ($this->equalMediaWidth) {
             $mediaScalingCorrection = 1;
 
@@ -133,7 +133,7 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
             // Recalculate gallery width
             $this->galleryData['width'] = floor($totalRowWidth / $mediaScalingCorrection);
 
-            // Automatic setting of width and height
+        // Automatic setting of width and height
         } else {
             $maxMediaWidth = (int)($galleryWidthMinusBorderAndSpacing / $this->galleryData['count']['columns']);
             foreach ($this->fileObjects as $key => $fileObject) {
@@ -184,19 +184,30 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
                 $fileObj = $this->fileObjects[$fileKey] ?? null;
 
                 if ($fileObj) {
+                    $fileExtension = $this->processorConfiguration['fileExtension'] ?? null;
+
                     if ($fileObj['properties']['type'] === 'image') {
                         $image = $this->getImageService()->getImage((string)$fileObj['properties']['fileReferenceUid'], null, true);
-                        $fileObj = $this->getFileUtility()->processFile($image, $this->mediaDimensions[$fileKey] ?? []);
+                        $fileObj = $this->getFileUtility()->processFile(
+                            $image,
+                            array_merge(
+                                ['fileExtension' => $fileExtension],
+                                $this->mediaDimensions[$fileKey] ?? []
+                            )
+                        );
 
                         if (isset($this->processorConfiguration['autogenerate.']['retina2x'],
                             $fileObj['properties']['dimensions']['width']) &&
                             (int)$this->processorConfiguration['autogenerate.']['retina2x'] === 1) {
                             $fileObj['urlRetina'] = $this->getFileUtility()->processFile(
                                 $image,
-                                [
-                                    'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::RETINA_RATIO,
-                                    'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::RETINA_RATIO,
-                                ]
+                                array_merge(
+                                    ['fileExtension' => $fileExtension],
+                                    [
+                                        'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::RETINA_RATIO,
+                                        'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::RETINA_RATIO,
+                                    ]
+                                )
                             )['publicUrl'];
                         }
 
@@ -205,10 +216,13 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
                                 (int)$this->processorConfiguration['autogenerate.']['lqip'] === 1) {
                             $fileObj['urlLqip'] = $this->getFileUtility()->processFile(
                                 $image,
-                                [
+                                array_merge(
+                                    ['fileExtension' => $fileExtension],
+                                    [
                                         'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::LQIP_RATIO,
                                         'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::LQIP_RATIO,
                                     ]
+                                )
                             )['publicUrl'];
                         }
                     }

--- a/Classes/DataProcessing/GalleryProcessor.php
+++ b/Classes/DataProcessing/GalleryProcessor.php
@@ -201,13 +201,11 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
                             (int)$this->processorConfiguration['autogenerate.']['retina2x'] === 1) {
                             $fileObj['urlRetina'] = $this->getFileUtility()->processFile(
                                 $image,
-                                array_merge(
-                                    ['fileExtension' => $fileExtension],
-                                    [
-                                        'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::RETINA_RATIO,
-                                        'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::RETINA_RATIO,
-                                    ]
-                                )
+                                [
+                                    'fileExtension' => $fileExtension,
+                                    'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::RETINA_RATIO,
+                                    'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::RETINA_RATIO,
+                                ]
                             )['publicUrl'];
                         }
 
@@ -216,13 +214,11 @@ class GalleryProcessor extends \TYPO3\CMS\Frontend\DataProcessing\GalleryProcess
                                 (int)$this->processorConfiguration['autogenerate.']['lqip'] === 1) {
                             $fileObj['urlLqip'] = $this->getFileUtility()->processFile(
                                 $image,
-                                array_merge(
-                                    ['fileExtension' => $fileExtension],
-                                    [
-                                        'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::LQIP_RATIO,
-                                        'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::LQIP_RATIO,
-                                    ]
-                                )
+                                [
+                                    'fileExtension' => $fileExtension,
+                                    'width' => $fileObj['properties']['dimensions']['width'] * FileUtility::LQIP_RATIO,
+                                    'height' => $fileObj['properties']['dimensions']['height'] * FileUtility::LQIP_RATIO,
+                                ]
                             )['publicUrl'];
                         }
                     }


### PR DESCRIPTION
This adds a new option to GalleryProcessor to render a certain image format.

```
    10 = FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor
    10 {
        processingConfiguration.delayProcessing = 1
    }
    20 = FriendsOfTYPO3\Headless\DataProcessing\GalleryProcessor
    20 {
        fileExtension = webp
    }
```

Related: #617 