### PR TITLE
[FEATURE] PageTitle handler for headless

### DIFF
--- a/Classes/Event/Listener/AfterCacheableContentIsGeneratedListener.php
+++ b/Classes/Event/Listener/AfterCacheableContentIsGeneratedListener.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Event\Listener;
+
+use FriendsOfTYPO3\Headless\Json\JsonEncoder;
+use TYPO3\CMS\Frontend\Event\AfterCacheableContentIsGeneratedEvent;
+
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+class AfterCacheableContentIsGeneratedListener
+{
+    public function __construct(private readonly JsonEncoder $encoder)
+    {
+    }
+
+    public function __invoke(AfterCacheableContentIsGeneratedEvent $event)
+    {
+        try {
+            $content = json_decode($event->getController()->content, true, 512, JSON_THROW_ON_ERROR);
+
+            if (($content['meta']['title'] ?? null) === null) {
+                return;
+            }
+
+            $content['meta']['title'] = $event->getController()->generatePageTitle();
+
+            $event->getController()->content = $this->encoder->encode($content);
+        } catch (\Throwable) {
+            return;
+        }
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -20,6 +20,7 @@ use FriendsOfTYPO3\Headless\DataProcessing\FlexFormProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\GalleryProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\MenuProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\RootSitesProcessor;
+use FriendsOfTYPO3\Headless\Event\Listener\AfterCacheableContentIsGeneratedListener;
 use FriendsOfTYPO3\Headless\Event\Listener\AfterLinkIsGeneratedListener;
 use FriendsOfTYPO3\Headless\Event\Listener\AfterPagePreviewUriGeneratedListener;
 use FriendsOfTYPO3\Headless\Event\Listener\LoginConfirmedEventListener;
@@ -77,6 +78,12 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
         'event.listener',
         ['identifier' => 'headless/AfterLinkIsGenerated']
     );
+    $services->set(AfterCacheableContentIsGeneratedListener::class)->tag(
+        'event.listener',
+        ['identifier' => 'headless/AfterCacheableContentIsGenerated']
+    );
+
+    $features = GeneralUtility::makeInstance(Features::class);
 
     if ($feloginInstalled) {
         $services->set(LoginConfirmedEventListener::class)->tag(
@@ -93,8 +100,6 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
     if ($cmsFormsInstalled) {
         $services->set(FormTranslationService::class)->arg('$runtimeCache', service('cache.runtime'))->public();
     }
-
-    $features = GeneralUtility::makeInstance(Features::class);
 
     if ($features->isFeatureEnabled('headless.overrideFluidTemplates')) {
         $templateService = $services->alias(

--- a/Tests/Unit/Event/Listener/AfterCacheableContentIsGeneratedListenerTest.php
+++ b/Tests/Unit/Event/Listener/AfterCacheableContentIsGeneratedListenerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FriendsOfTYPO3\Headless\Tests\Unit\Event\Listener;
+
+use FriendsOfTYPO3\Headless\Event\Listener\AfterCacheableContentIsGeneratedListener;
+use FriendsOfTYPO3\Headless\Json\JsonEncoder;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Event\AfterCacheableContentIsGeneratedEvent;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+use function json_encode;
+
+class AfterCacheableContentIsGeneratedListenerTest extends UnitTestCase
+{
+    use ProphecyTrait;
+
+    public function testNotModifiedWithInvalidJsonContent(): void
+    {
+        $listener = new AfterCacheableContentIsGeneratedListener(new JsonEncoder());
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $controller = $this->prophesize(TypoScriptFrontendController::class);
+        $controller->content = '';
+
+        $event = new AfterCacheableContentIsGeneratedEvent($request->reveal(), $controller->reveal(), 'abc', false);
+
+        $listener($event);
+
+        self::assertSame('', $event->getController()->content);
+    }
+
+    public function testNotModifiedWhileValidJson(): void
+    {
+        $listener = new AfterCacheableContentIsGeneratedListener(new JsonEncoder());
+
+        $content = json_encode(['someCustomPageWithoutMeta' => ['title' => 'test before event']]);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $controller = $this->prophesize(TypoScriptFrontendController::class);
+        $controller->content = $content;
+        $controller->generatePageTitle()->willReturn('Modified title via PageTitleManager');
+
+        $event = new AfterCacheableContentIsGeneratedEvent($request->reveal(), $controller->reveal(), 'abc', false);
+
+        $listener($event);
+
+        self::assertSame($content, $event->getController()->content);
+    }
+
+    public function testModifiedPageTitle(): void
+    {
+        $listener = new AfterCacheableContentIsGeneratedListener(new JsonEncoder());
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $controller = $this->prophesize(TypoScriptFrontendController::class);
+        $controller->content = json_encode(['meta' => ['title' => 'test before event']]);
+        $controller->generatePageTitle()->willReturn('Modified title via PageTitleProviderManager');
+
+        $event = new AfterCacheableContentIsGeneratedEvent($request->reveal(), $controller->reveal(), 'abc', false);
+
+        $listener($event);
+
+        self::assertSame(json_encode(['meta' => ['title' => 'Modified title via PageTitleProviderManager']]), $event->getController()->content);
+    }
+}


### PR DESCRIPTION
Introduce listener to modify `meta.title` property on page render via call to `TSFE->generatePageTitle` with allows to get processed page title and/or set via extbase plugins

Resolves #543