### PR TITLE
[FIX] Import custom GalleryProcessor instead of processor from fluid_…

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -17,6 +17,7 @@ use FriendsOfTYPO3\Headless\ContentObject\JsonContentObject;
 use FriendsOfTYPO3\Headless\DataProcessing\DatabaseQueryProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\FilesProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\FlexFormProcessor;
+use FriendsOfTYPO3\Headless\DataProcessing\GalleryProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\MenuProcessor;
 use FriendsOfTYPO3\Headless\DataProcessing\RootSitesProcessor;
 use FriendsOfTYPO3\Headless\Event\Listener\AfterLinkIsGeneratedListener;
@@ -31,7 +32,6 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Form\Controller\FormFrontendController;
-use FriendsOfTYPO3\Headless\DataProcessing\GalleryProcessor;
 use TYPO3\CMS\FrontendLogin\Controller\LoginController;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -31,7 +31,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Form\Controller\FormFrontendController;
-use TYPO3\CMS\Frontend\DataProcessing\GalleryProcessor;
+use FriendsOfTYPO3\Headless\DataProcessing\GalleryProcessor;
 use TYPO3\CMS\FrontendLogin\Controller\LoginController;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;


### PR DESCRIPTION
…styled_content

I get the following error in TYPO3 v12:

![grafik](https://github.com/TYPO3-Headless/headless/assets/43951441/0118cd74-85ef-4f14-b536-8b178f0d0164)

This has to do with fluid_styled_content now using identifiers for setting the DataProcessors inside the TypoScript configuration and not the full class name anymore.

The origin of this error seems to be that in your Services.php you register "headless-gallery" as an identifier for "TYPO3\CMS\Frontend\DataProcessing\GalleryProcessor" and not for your custom DataProcessor "FriendsOfTYPO3\Headless\DataProcessing\GalleryProcessor" so the identifier is overridden and the DataProcessing of the regular images stops working.