### PR TITLE
Simplify over-enginered optionSplit

### DIFF
--- a/Configuration/TypoScript/ContentElement/ContentElement.typoscript
+++ b/Configuration/TypoScript/ContentElement/ContentElement.typoscript
@@ -36,19 +36,10 @@ lib.contentElement {
             }
             stdWrap.split {
                 token = ###BREAK###
-                cObjNum = 1 |*|2|*| 3
-                1 {
-                    current = 1
-                    stdWrap.wrap = |
-                }
-                2 {
-                    current = 1
-                    stdWrap.wrap = ,|
-                }
-                3 {
-                    current = 1
-                    stdWrap.wrap = |
-                }
+                cObjNum = 1|*|2|*|1
+                1.current = 1
+                2.current = 1
+                2.stdWrap.wrap = ,|
             }
         }
         appearance =< lib.appearance

--- a/Configuration/TypoScript/ContentElement/Shortcut.typoscript
+++ b/Configuration/TypoScript/ContentElement/Shortcut.typoscript
@@ -17,21 +17,10 @@ tt_content.shortcut {
                         innerWrap = [|]
                         split {
                             token = ###BREAK###
-                            cObjNum = 1 |*|2|*| 3
-                            1 {
-                                current = 1
-                                stdWrap.wrap = |
-                            }
-
-                            2 {
-                                current = 1
-                                stdWrap.wrap = ,|
-                            }
-
-                            3 {
-                                current = 1
-                                stdWrap.wrap = |
-                            }
+                            cObjNum = 1|*|2|*|1
+                            1.current = 1
+                            2.current = 1
+                            2.stdWrap.wrap = ,|
                         }
                     }
                 }

--- a/Configuration/TypoScript/Page/Categories.typoscript
+++ b/Configuration/TypoScript/Page/Categories.typoscript
@@ -20,18 +20,9 @@ categories {
     }
     stdWrap.split {
         token = ###BREAK###
-        cObjNum = 1 |*|2|*| 3
-        1 {
-            current = 1
-            stdWrap.wrap = |
-        }
-        2 {
-            current = 1
-            stdWrap.wrap = ,|
-        }
-        3 {
-            current = 1
-            stdWrap.wrap = |
-        }
+        cObjNum = 1|*|2|*|1
+        1.current = 1
+        2.current = 1
+        2.stdWrap.wrap = ,|
     }
 }

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -247,16 +247,10 @@ Here's an example of how you can create a JSON array of multiple objects from a 
           # Replace 'inner tokens' by comma, remove others
           split {
             token = ###BREAK###
-            cObjNum = 1 |*|2|*| 3
-            1 {
-              current = 1
-              stdWrap.wrap = |
-            }
-
-            2 < .1
+            cObjNum = 1|*|2|*|1
+            1.current = 1
+            2.current = 1
             2.stdWrap.wrap = ,|
-
-            3 < .1
           }
         }
       }


### PR DESCRIPTION
The optionSplit used in CTypes `shortcut` and other places is unnecessarily complicated. This simplifies that.