### PR TITLE
FIX: Deprecated: Do not provide $request as third argument

### DIFF
--- a/Tests/Unit/ContentObject/JsonContentObjectTest.php
+++ b/Tests/Unit/ContentObject/JsonContentObjectTest.php
@@ -83,7 +83,8 @@ class JsonContentObjectTest extends UnitTestCase
         ];
 
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-        $contentObjectRenderer->start([], 'tt_content', $this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->setRequest($this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->start([], 'tt_content');
 
         $factory = $this->prophesize(ContentObjectFactory::class);
         $factory->getContentObject(Argument::type('string'), Argument::type('object'), Argument::type('object'))

--- a/Tests/Unit/DataProcessing/RootSitesProcessorTest.php
+++ b/Tests/Unit/DataProcessing/RootSitesProcessorTest.php
@@ -39,7 +39,8 @@ class RootSitesProcessorTest extends UnitTestCase
         $processor = new RootSitesProcessor();
 
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-        $contentObjectRenderer->start([], 'tt_content', $this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->setRequest($this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->start([], 'tt_content');
         $contentObjectRenderer->data['uid'] = 1;
         $conf = [];
         $conf['siteProvider'] = TestSiteProvider::class;
@@ -77,7 +78,8 @@ class RootSitesProcessorTest extends UnitTestCase
         $processor = new RootSitesProcessor();
 
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-        $contentObjectRenderer->start([], 'tt_content', $this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->setRequest($this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->start([], 'tt_content');
 
         $conf = [];
         self::assertEquals([], $processor->process($contentObjectRenderer, [], $conf, []));
@@ -91,7 +93,8 @@ class RootSitesProcessorTest extends UnitTestCase
         $processor = new RootSitesProcessor();
 
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-        $contentObjectRenderer->start([], 'tt_content', $this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->setRequest($this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->start([], 'tt_content');
         $contentObjectRenderer->data['uid'] = 1;
         $conf = [];
         $conf['siteProvider'] = \stdClass::class;
@@ -107,7 +110,8 @@ class RootSitesProcessorTest extends UnitTestCase
         $processor = new RootSitesProcessor();
 
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-        $contentObjectRenderer->start([], 'tt_content', $this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->setRequest($this->prophesize(ServerRequestInterface::class)->reveal());
+        $contentObjectRenderer->start([], 'tt_content');
         $contentObjectRenderer->data['uid'] = 1;
         $conf = [];
         $conf['siteSchema'] = \stdClass::class;


### PR DESCRIPTION
FIX: Deprecated: Do not provide $request as third argument to start(). Call setRequest() before, instead.

Found this while working on #626 