### PR TITLE
[BUGFIX] Set correct typoscript key for categories

### DIFF
--- a/Configuration/TypoScript/Page/Categories.typoscript
+++ b/Configuration/TypoScript/Page/Categories.typoscript
@@ -1,5 +1,5 @@
-categories = COA
-categories {
+lib.categories = COA
+lib.categories {
     10 = CONTENT
     10 {
         table = sys_category


### PR DESCRIPTION
I think the key is wrong. 

In the PageConfiguration.typoscript file, there is a reference to lib.categories, but it does not exist.