### PR TITLE
[FEATURE] Add option "ifEmptyUnsetKey" to JSON cObject

### DIFF
--- a/Classes/ContentObject/JsonContentObject.php
+++ b/Classes/ContentObject/JsonContentObject.php
@@ -121,6 +121,9 @@ class JsonContentObject extends AbstractContentObject implements LoggerAwareInte
                 if ((int)($conf['ifEmptyReturnNull'] ?? 0) === 1 && $content[$theKey] === '') {
                     $content[$theKey] = null;
                 }
+                if ((int)($conf['ifEmptyUnsetKey'] ?? 0) === 1 && ($content[$theKey] === '' || $content[$theKey] === false)) {
+                    unset($content[$theKey]);
+                }
                 if (!empty($contentDataProcessing['dataProcessing.'])) {
                     $content[rtrim($theKey, '.')] = $this->processFieldWithDataProcessing($contentDataProcessing);
                 }


### PR DESCRIPTION
This TypoScript option works similar to "ifEmptyReturnNull", however, the option uses the unset() feature to actually remove the key from the json output instead of setting this to null.

The code checks for "" and an explicit "false" (bool) when using the cObject = BOOL

Fixes: #649