### PR TITLE
[FEATURE] Use shared TypoScript lib for headless pages

### DIFF
--- a/Configuration/TypoScript/Configuration/Domains.typoscript
+++ b/Configuration/TypoScript/Configuration/Domains.typoscript
@@ -1,20 +1,7 @@
-headless_domains = PAGE
+headless_domains < lib.headlessPage
 headless_domains {
     typeNum = 835
 
-    config {
-        no_cache = 0
-        sendCacheHeaders = 1
-        debug = 0
-        admPanel = 0
-        disableAllHeaderCode = 1
-        additionalHeaders.10 {
-            header = Content-Type: application/json; charset=utf-8
-            replace = 1
-        }
-    }
-
-    10 = JSON
     10 {
         dataProcessing {
             10 = FriendsOfTYPO3\Headless\DataProcessing\RootSitesProcessor

--- a/Configuration/TypoScript/Configuration/InitialDataConfiguration.typoscript
+++ b/Configuration/TypoScript/Configuration/InitialDataConfiguration.typoscript
@@ -1,19 +1,7 @@
-initialData = PAGE
+initialData < lib.headlessPage
 initialData {
     typeNum = 834
-    config {
-        no_cache = 0
-        sendCacheHeaders = 1
-        debug = 0
-        admPanel = 0
-        disableAllHeaderCode = 1
-        additionalHeaders.10 {
-            header = Content-Type: application/json; charset=utf-8
-            replace = 1
-        }
-    }
 
-    10 = JSON
     10 {
         fields {
             navigation = JSON

--- a/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
+++ b/Configuration/TypoScript/Configuration/PageConfiguration.typoscript
@@ -1,19 +1,7 @@
-page = PAGE
+page < lib.headlessPage
 page {
     typeNum = 0
-    config {
-        no_cache = 0
-        sendCacheHeaders = 1
-        debug = 0
-        admPanel = 0
-        disableAllHeaderCode = 1
-        additionalHeaders.10 {
-            header = Content-Type: application/json; charset=utf-8
-            replace = 1
-        }
-    }
 
-    10 = JSON
     10 {
         fields {
             id = INT

--- a/Configuration/TypoScript/Page/HeadlessPage.typoscript
+++ b/Configuration/TypoScript/Page/HeadlessPage.typoscript
@@ -1,17 +1,17 @@
 lib.headlessPage = PAGE
 lib.headlessPage {
-  config {
-    no_cache = 0
-    sendCacheHeaders = 1
-    debug = 0
-    admPanel = 0
-    disableAllHeaderCode = 1
-    additionalHeaders.10 {
-      header = Content-Type: application/json; charset=utf-8
-      replace = 1
+      config {
+        no_cache = 0
+        sendCacheHeaders = 1
+        debug = 0
+        admPanel = 0
+        disableAllHeaderCode = 1
+        additionalHeaders.10 {
+            header = Content-Type: application/json; charset=utf-8
+            replace = 1
+        }
     }
-  }
 
-  10 = JSON
+    10 = JSON
 
 }

--- a/Configuration/TypoScript/Page/HeadlessPage.typoscript
+++ b/Configuration/TypoScript/Page/HeadlessPage.typoscript
@@ -1,0 +1,17 @@
+lib.headlessPage = PAGE
+lib.headlessPage {
+  config {
+    no_cache = 0
+    sendCacheHeaders = 1
+    debug = 0
+    admPanel = 0
+    disableAllHeaderCode = 1
+    additionalHeaders.10 {
+      header = Content-Type: application/json; charset=utf-8
+      replace = 1
+    }
+  }
+
+  10 = JSON
+
+}

--- a/Configuration/TypoScript/Page/HeadlessPage.typoscript
+++ b/Configuration/TypoScript/Page/HeadlessPage.typoscript
@@ -1,6 +1,6 @@
 lib.headlessPage = PAGE
 lib.headlessPage {
-      config {
+    config {
         no_cache = 0
         sendCacheHeaders = 1
         debug = 0


### PR DESCRIPTION
This way we reduce code duplications and make it easier to add new headless pages (typeNums).