### PR TITLE
[BUGFIX] Correct `linkText` value in headerLink property

### DIFF
--- a/Configuration/TypoScript/ContentElement/ContentElementWithHeader.typoscript
+++ b/Configuration/TypoScript/ContentElement/ContentElementWithHeader.typoscript
@@ -21,7 +21,6 @@ lib.contentElementWithHeader {
                 }
                 headerLink = TEXT
                 headerLink {
-                    field = header_link
                     htmlSpecialChars = 1
                     typolink {
                         parameter {

--- a/Tests/Functional/ContentTypes/BaseContentTypeTest.php
+++ b/Tests/Functional/ContentTypes/BaseContentTypeTest.php
@@ -54,12 +54,12 @@ abstract class BaseContentTypeTest extends BaseTest
         self::assertTrue(isset($contentElementContent['headerLink']), 'headerLink not set');
     }
 
-    protected function checkHeaderFieldsLink($contentElement, $link, $urlPrefix, $target)
+    protected function checkHeaderFieldsLink($contentElement, $linkText, $urlPrefix, $target)
     {
         $contentElementHeaderFieldsLink = $contentElement['content']['headerLink'];
 
         self::assertIsArray($contentElementHeaderFieldsLink, 'headerLink not an array');
-        self::assertEquals($link, $contentElementHeaderFieldsLink['linkText'], 'link mismatch');
+        self::assertEquals($linkText, $contentElementHeaderFieldsLink['linkText'], 'linkText mismatch');
         self::assertStringStartsWith($urlPrefix, $contentElementHeaderFieldsLink['href'], 'url mismatch');
         self::assertEquals($target, $contentElementHeaderFieldsLink['target'], 'target mismatch');
     }

--- a/Tests/Functional/ContentTypes/BasicListElementTest.php
+++ b/Tests/Functional/ContentTypes/BasicListElementTest.php
@@ -30,7 +30,7 @@ class BasicListElementTest extends BaseContentTypeTest
         $this->checkDefaultContentFields($contentElement, 6, 1, 'BasicList', 0);
         $this->checkAppearanceFields($contentElement, 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement, 'Header', 'SubHeader', 1, 2);
-        $this->checkHeaderFieldsLink($contentElement, 't3://page?uid=2 _blank LinkClass LinkTitle parameter=999', '/page1?parameter=999&cHash=', '_blank');
+        $this->checkHeaderFieldsLink($contentElement, 'Page 1', '/page1?parameter=999&cHash=', '_blank');
         self::assertFalse(isset($contentElement['content']['bodytext']));
     }
 }

--- a/Tests/Functional/ContentTypes/BulletsElementTest.php
+++ b/Tests/Functional/ContentTypes/BulletsElementTest.php
@@ -32,7 +32,7 @@ class BulletsElementTest extends BaseContentTypeTest
         $this->checkDefaultContentFields($contentElement, 8, 1, 'bullets', 0);
         $this->checkAppearanceFields($contentElement, 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement, 'Header', 'SubHeader', 1, 2);
-        $this->checkHeaderFieldsLink($contentElement, 't3://page?uid=2 _blank LinkClass LinkTitle parameter=999', '/page1?parameter=999&cHash=', '_blank');
+        $this->checkHeaderFieldsLink($contentElement, 'Page 1', '/page1?parameter=999&cHash=', '_blank');
 
         self::assertEquals(1, $contentElement['content']['bulletsType']);
         self::assertTrue(is_array($contentElement['content']['bodytext']));

--- a/Tests/Functional/ContentTypes/HeaderElementTest.php
+++ b/Tests/Functional/ContentTypes/HeaderElementTest.php
@@ -30,6 +30,6 @@ class HeaderElementTest extends BaseContentTypeTest
         $this->checkDefaultContentFields($contentElement, 3, 1, 'header', 0);
         $this->checkAppearanceFields($contentElement, 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement, 'Header', 'SubHeader', 1, 2);
-        $this->checkHeaderFieldsLink($contentElement, 't3://page?uid=2 _blank LinkClass LinkTitle parameter=999', '/page1?parameter=999&cHash=', '_blank');
+        $this->checkHeaderFieldsLink($contentElement, 'Page 1', '/page1?parameter=999&cHash=', '_blank');
     }
 }

--- a/Tests/Functional/ContentTypes/ShortcutElementTest.php
+++ b/Tests/Functional/ContentTypes/ShortcutElementTest.php
@@ -45,7 +45,7 @@ class ShortcutElementTest extends BaseContentTypeTest
         $this->checkDefaultContentFields($contentElement['content']['shortcut'][1], 1, 1, 'text', 0, 'SysCategory1Title,SysCategory2Title');
         $this->checkAppearanceFields($contentElement['content']['shortcut'][1], 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement['content']['shortcut'][1], 'Header', 'SubHeader', 1, 2);
-        $this->checkHeaderFieldsLink($contentElement['content']['shortcut'][1], 't3://page?uid=2 _blank LinkClass LinkTitle parameter=999', '/page1?parameter=999&cHash=', '_blank');
+        $this->checkHeaderFieldsLink($contentElement['content']['shortcut'][1], 'Page 1', '/page1?parameter=999&cHash=', '_blank');
         self::assertStringContainsString('<a href="/page1?parameter=999&amp;cHash=', $contentElement['content']['shortcut'][1]['content']['bodytext']);
     }
 }

--- a/Tests/Functional/ContentTypes/TableElementTest.php
+++ b/Tests/Functional/ContentTypes/TableElementTest.php
@@ -32,7 +32,7 @@ class TableElementTest extends BaseContentTypeTest
         $this->checkDefaultContentFields($contentElement, 7, 1, 'table', 0);
         $this->checkAppearanceFields($contentElement, 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement, 'Header', 'SubHeader', 1, 2);
-        $this->checkHeaderFieldsLink($contentElement, 't3://page?uid=2 _blank LinkClass LinkTitle parameter=999', '/page1?parameter=999&cHash=', '_blank');
+        $this->checkHeaderFieldsLink($contentElement, 'Page 1', '/page1?parameter=999&cHash=', '_blank');
 
         self::assertEquals('TableCaption', $contentElement['content']['tableCaption']);
         self::assertEquals(1, $contentElement['content']['tableHeaderPosition']);

--- a/Tests/Functional/ContentTypes/TextElementTest.php
+++ b/Tests/Functional/ContentTypes/TextElementTest.php
@@ -30,7 +30,7 @@ class TextElementTest extends BaseContentTypeTest
         $this->checkDefaultContentFields($contentElement, 1, 1, 'text', 0, 'SysCategory1Title,SysCategory2Title');
         $this->checkAppearanceFields($contentElement, 'layout-1', 'Frame', 'SpaceBefore', 'SpaceAfter');
         $this->checkHeaderFields($contentElement, 'Header', 'SubHeader', 1, 2);
-        $this->checkHeaderFieldsLink($contentElement, 't3://page?uid=2 _blank LinkClass LinkTitle parameter=999', '/page1?parameter=999&cHash=', '_blank');
+        $this->checkHeaderFieldsLink($contentElement, 'Page 1', '/page1?parameter=999&cHash=', '_blank');
 
         // typolink parser was called on bodytext
         self::assertStringContainsString('<a href="/page1?parameter=999&amp;cHash=', $contentElement['content']['bodytext']);


### PR DESCRIPTION
Due to the additional option `field = header_link` setting the output of `linkText` value was always something like `t3://page?uid=13` for internal links. But it would be better to let typolink always handle the `linkText` to have it replaced with e.g the page title.

Current:
```json
"headerLink": {
  "href": "/my-page",
  "target": null,
  "class": null,
  "title": null,
  "linkText": "t3://page?uid=13",
  "additionalAttributes": []
}
```

Fixed:
```json
"headerLink": {
  "href": "/my-page",
  "target": null,
  "class": null,
  "title": null,
  "linkText": "My Page",
  "additionalAttributes": []
}
```