### PR TITLE
[BUGFIX] Get correct page id for a shortcut

### DIFF
--- a/Classes/Event/Listener/AfterLinkIsGeneratedListener.php
+++ b/Classes/Event/Listener/AfterLinkIsGeneratedListener.php
@@ -33,7 +33,7 @@ final class AfterLinkIsGeneratedListener
         }
 
         $page = $result->getLinkConfiguration()['page'] ?? null;
-        if ($page != null && $page['doktype'] == PageRepository::DOKTYPE_SHORTCUT) {
+        if ($page != null && $page['doktype'] === PageRepository::DOKTYPE_SHORTCUT) {
             $pageId = $page['shortcut'];
         } else {
             $pageId = $result->getLinkConfiguration()['parameter'] ?? 0;

--- a/Classes/Event/Listener/AfterLinkIsGeneratedListener.php
+++ b/Classes/Event/Listener/AfterLinkIsGeneratedListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Headless\Event\Listener;
 
 use FriendsOfTYPO3\Headless\Utility\HeadlessFrontendUrlInterface;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Frontend\Event\AfterLinkIsGeneratedEvent;
@@ -31,7 +32,12 @@ final class AfterLinkIsGeneratedListener
             return;
         }
 
-        $pageId = $result->getLinkConfiguration()['parameter'] ?? 0;
+        $page = $result->getLinkConfiguration()['page'] ?? null;
+        if ($page != null && $page['doktype'] == PageRepository::DOKTYPE_SHORTCUT) {
+            $pageId = $page['shortcut'];
+        } else {
+            $pageId = $result->getLinkConfiguration()['parameter'] ?? 0;
+        }
 
         if (isset($result->getLinkConfiguration()['parameter.'])) {
             $pageId = (int)($this->linkService->resolve($event->getContentObjectRenderer()->parameters['href'] ?? '')['pageuid'] ?? 0);


### PR DESCRIPTION
When creating a shortcut in TYPO3 that points to a different root page, an incorrect link is generated.

I hope I have fixed it correctly.