### PR TITLE
FileUtility processing files considered as images

### DIFF
--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -97,7 +97,7 @@ class FileUtility
             'linkData' => $linkData ?? null,
         ];
 
-        if ($fileRenderer === null && $fileReference->getType() === AbstractFile::FILETYPE_IMAGE) {
+        if ($fileRenderer === null && GeneralUtility::inList($GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], $fileReference->getExtension())) {
             if (!$delayProcessing && $fileReference->getMimeType() !== 'image/svg+xml') {
                 $fileReference = $this->processImageFile($fileReference, $arguments, $cropVariant);
             }

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -185,6 +185,10 @@ class FileUtility
                 'crop' => $cropArea->isEmpty() ? null : $cropArea->makeAbsoluteBasedOnFile($image),
             ];
             if (!empty($arguments['fileExtension'])) {
+                if(!GeneralUtility::inList($GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], (string)$arguments['fileExtension']))
+                {
+                    throw new Exception('The extension ' . $arguments['fileExtension'] . ' is not specified in $GLOBALS[\'TYPO3_CONF_VARS\'][\'GFX\'][\'imagefile_ext\'] as a valid image file extension and can not be processed.', 1701250543);
+                }
                 $processingInstructions['fileExtension'] = $arguments['fileExtension'];
             }
             return $this->imageService->applyProcessingInstructions($image, $processingInstructions);


### PR DESCRIPTION
Greetings team!
This PR is related to issue #247 where some file extensions are not detected as image files.