### PR TITLE
[BUGFIX] Fix for sitemap provider

### DIFF
--- a/Classes/Seo/XmlSitemap/PagesXmlSitemapDataProvider.php
+++ b/Classes/Seo/XmlSitemap/PagesXmlSitemapDataProvider.php
@@ -20,7 +20,7 @@ class PagesXmlSitemapDataProvider extends \TYPO3\CMS\Seo\XmlSitemap\PagesXmlSite
     {
         $typoLinkConfig = [
             'parameter' => $data['uid'],
-            'forceAbsoluteUrl' => 0,
+            'forceAbsoluteUrl' => 1,
         ];
 
         $data['loc'] = $this->cObj->typoLink_URL($typoLinkConfig);

--- a/Classes/Seo/XmlSitemap/RecordsXmlSitemapDataProvider.php
+++ b/Classes/Seo/XmlSitemap/RecordsXmlSitemapDataProvider.php
@@ -34,7 +34,7 @@ class RecordsXmlSitemapDataProvider extends \TYPO3\CMS\Seo\XmlSitemap\RecordsXml
         $typoLinkConfig = [
             'parameter' => $pageId,
             'additionalParams' => $additionalParamsString ? '&' . $additionalParamsString : '',
-            'forceAbsoluteUrl' => 0,
+            'forceAbsoluteUrl' => 1,
         ];
 
         $data['loc'] = $this->cObj->typoLink_URL($typoLinkConfig);


### PR DESCRIPTION
Set property 'forceAbsoluteUrl' at 1 to create absolute urls in sitemap to be useful with [TYPO3 Site crawler](https://extensions.typo3.org/extension/crawler) and to be correct with [Google sitemap best practices](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#sitemap-best-practices)