### PR TITLE
[BUGFIX] Fix endless loop for CType menu_section

### DIFF
--- a/Configuration/TypoScript/ContentElement/MenuSection.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuSection.typoscript
@@ -49,6 +49,14 @@ tt_content.menu_section {
                                             as = media
                                         }
                                     }
+                                    # Only render the required fields (and not the entire
+                                    # tt_content record with its bloated rendering instructions)
+                                    fields {
+                                        uid = TEXT
+                                        uid.field = uid
+                                        header = TEXT
+                                        header.field = header
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
In case the CE menu_section itself is with `sectionIndex=1` we run into an endless loop when using the default tt_content rendering instructions to render the menu items.

Resolves: #715