### PR TITLE
[BUGFIX] Fix linkResult configuration in simplified file output

### DIFF
--- a/Classes/DataProcessing/DataProcessingTrait.php
+++ b/Classes/DataProcessing/DataProcessingTrait.php
@@ -26,7 +26,7 @@ trait DataProcessingTrait
             if (isset($processorConfiguration['as'], $processedData[$processorConfiguration['as']])
                 && is_array($processedData[$processorConfiguration['as']])) {
                 foreach ($processedData[$processorConfiguration['as']] as &$item) {
-                    if (isset($item['data'])) {
+                    if (is_array($item) && isset($item['data'])) {
                         unset($item['data']);
                     }
 


### PR DESCRIPTION
I tried using the simplified file output with `legacyReturn = 0` but in addition with `linkResult = 1` this leads to an error in the `removeDataIfnotAppendInConfiguration` function.