### PR TITLE
Render form validation errors with arguments

### DIFF
--- a/Classes/XClass/Controller/FormFrontendController.php
+++ b/Classes/XClass/Controller/FormFrontendController.php
@@ -241,7 +241,7 @@ class FormFrontendController extends \TYPO3\CMS\Form\Controller\FormFrontendCont
         $parsedErrors = [];
 
         foreach ($errors as $key => $errorObj) {
-            $parsedErrors[str_replace($formIdentifier . '.', '', $key)] = $errorObj[0]->getMessage();
+            $parsedErrors[str_replace($formIdentifier . '.', '', $key)] = $errorObj[0]->render();
         }
 
         return count($parsedErrors) ? $parsedErrors : null;


### PR DESCRIPTION
This will render form validation errors with arguments, replacing placeholders with arguments if necessary (e.g. `The date "123" was not recognized (for format "Y-m-d\TH:i:sP").` for `The date "%s" was not recognized (for format "%s").`).