### PR TITLE
[BUGFIX] Don't render double slashes in file URLs

### DIFF
--- a/Classes/XClass/ResourceLocalDriver.php
+++ b/Classes/XClass/ResourceLocalDriver.php
@@ -53,10 +53,12 @@ class ResourceLocalDriver extends LocalDriver
             };
 
             if ($basePath !== '') {
-                $frontendUri = (new Uri($urlUtility->getFrontendUrl()));
+                $frontendUri = new Uri($urlUtility->getFrontendUrl());
+                $proxyUri = new Uri($urlUtility->getProxyUrl());
+                $baseUri = new Uri($basePath);
 
-                $path = new Uri(trim($basePath, '/'));
-                $this->configuration['baseUri'] = (string)$frontendUri->withPath('/' . trim((new Uri($urlUtility->getProxyUrl()))->getPath(), '/') . '/' . trim($path->getPath(), '/'));
+                $path = trim($proxyUri->getPath(), '/') . '/' . trim($baseUri->getPath(), '/');
+                $this->configuration['baseUri'] = (string)$frontendUri->withPath('/' . trim($path, '/'));
             } else {
                 $this->configuration['baseUri'] = $urlUtility->getStorageProxyUrl();
             }


### PR DESCRIPTION
Without a frontendApiProxy in the site config, URLs to local files contain two slashes like www.mysite.org//fileadmin/my-image.jpg