### PR TITLE
[FEATURE] Add support for f:form.* viewhelper

### DIFF
--- a/Classes/XClass/ViewHelpers/Form/AbstractFormFieldViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/AbstractFormFieldViewHelper.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper as CoreAbstractFormFieldViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper;
+
+/**
+ * Abstract Form ViewHelper. Bundles functionality related to direct property access of objects in other Form ViewHelpers.
+ *
+ * If you set the "property" attribute to the name of the property to resolve from the object, this class will
+ * automatically set the name and value of a form element.
+ *
+ * Note this set of ViewHelpers is tailored to be used only in extbase context.
+ */
+abstract class AbstractFormFieldViewHelper extends CoreAbstractFormFieldViewHelper
+{
+    protected array $data = [];
+
+    public function render(): string
+    {
+        parent::render();
+
+        $attributes = [];
+        foreach ($this->tag->getAttributes() as $key => $value) {
+            if (str_starts_with($key, 'data-')) {
+                $key = substr($key, strpos('data-', $key) + 5);
+                $attributes['data'][$key] = $value;
+                continue;
+            }
+
+            $attributes[$key] = $value;
+        }
+        return json_encode($attributes);
+    }
+
+    /**
+     * Renders a hidden field with the same name as the element, to make sure the empty value is submitted
+     * in case nothing is selected. This is needed for checkbox and multiple select fields
+     */
+    protected function renderHiddenFieldForEmptyValue(): string
+    {
+        $hiddenFieldNames = [];
+        $viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
+        if ($viewHelperVariableContainer->exists(
+            FormViewHelper::class,
+            'renderedHiddenFields'
+        )
+        ) {
+            $hiddenFieldNames = $viewHelperVariableContainer->get(
+                FormViewHelper::class,
+                'renderedHiddenFields'
+            );
+        }
+        $fieldName = $this->getName();
+        if (substr($fieldName, -2) === '[]') {
+            $fieldName = substr($fieldName, 0, -2);
+        }
+        if (!in_array($fieldName, $hiddenFieldNames, true)) {
+            $hiddenFieldNames[] = $fieldName;
+            $viewHelperVariableContainer->addOrUpdate(
+                FormViewHelper::class,
+                'renderedHiddenFields',
+                $hiddenFieldNames
+            );
+            return json_encode($this->addHiddenField(htmlspecialchars($fieldName), ''));
+        }
+        return '';
+    }
+
+    protected function addHiddenField(string $name, mixed $value): array
+    {
+        $tmp = [];
+        $tmp['name'] = $name;
+        $tmp['type'] = 'hidden';
+        $tmp['value'] = $value;
+
+        return $tmp;
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/ButtonViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/ButtonViewHelper.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * Creates a button.
+ *
+ * Examples
+ * ========
+ *
+ * Defaults::
+ *
+ *    <f:form.button>Send Mail</f:form.button>
+ *
+ * Output::
+ *
+ *    {
+ *        "type": "submit"
+ *        "content": "Send mail"
+ *    }
+ *
+ * Disabled cancel button with some HTML5 attributes::
+ *
+ *    <f:form.button type="reset" disabled="disabled"
+ *        name="buttonName" value="buttonValue"
+ *        formmethod="post" formnovalidate="formnovalidate"
+ *    >
+ *        Cancel
+ *    </f:form.button>
+ *
+ * Output::
+ *
+ *    {
+ *      "disabled": "disabled",
+ *      "formmethod": "post",
+ *      "formnovalidate": "formnovalidate",
+ *      "name": "tx_extension_plugin[buttonName]",
+ *      "type": "reset",
+ *      "value": "buttonValue",
+ *      "content": "Cancel"
+ *    },
+ */
+final class ButtonViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('type', 'string', 'Specifies the type of button (e.g. "button", "reset" or "submit")', false, 'submit');
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $type = $this->arguments['type'];
+        $name = $this->getName();
+        $this->registerFieldNameForFormTokenGeneration($name);
+
+        $this->data['name'] = $name;
+        $this->data['type'] = $type;
+
+        $value = $this->getValueAttribute();
+
+        if ($value !== null) {
+            $this->data['value'] = $value;
+        }
+
+        $this->data['content'] = (string)$this->renderChildren();
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/CheckboxViewHelper.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+use Traversable;
+
+/**
+ * ViewHelper which creates a simple checkbox :html:`<input type="checkbox">`.
+ *
+ * Examples
+ * ========
+ *
+ * Simple one
+ * ----------
+ *
+ * ::
+ *
+ *    <f:form.checkbox name="myCheckBox" value="someValue" />
+ *
+ * Output::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[myCheckBox]",
+ *      "type": "hidden",
+ *      "value": ""
+ *    },
+ *    {
+ *      "name": "tx_extension_plugin[myCheckBox]",
+ *      "type": "checkbox",
+ *      "value": "someValue"
+ *    }
+ *
+ * Preselect
+ * ---------
+ *
+ * ::
+ *
+ *    <f:form.checkbox name="myCheckBox" value="someValue" checked="{object.value} == 5" />
+ *
+ * Output::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[myCheckBox]",
+ *      "type": "checkbox",
+ *      "value": "someValue",
+ *      "checked": "checked"
+ *    },
+ *
+ * Depending on bound ``object`` to surrounding :ref:`f:form <typo3-fluid-form>`.
+ *
+ * Bind to object property
+ * -----------------------
+ *
+ * ::
+ *
+ *    <f:form.checkbox property="interests" value="TYPO3" multiple="1" />
+ *
+ * Output::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[customer][interests]",
+ *      "type": "hidden",
+ *      "value": ""
+ *    },
+ *    {
+ *      "name": "tx_extension_plugin[customer][interests][]",
+ *      "type": "checkbox",
+ *      "value": "TYPO3"
+ *    },
+ *
+ * Depending on property ``interests``.
+ */
+final class CheckboxViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument(
+            'errorClass',
+            'string',
+            'CSS class to set if there are errors for this ViewHelper',
+            false,
+            'f3-form-error'
+        );
+        $this->registerArgument('value', 'string', 'Value of input tag. Required for checkboxes', true);
+        $this->registerArgument('checked', 'bool', 'Specifies that the input element should be preselected');
+        $this->registerArgument('multiple', 'bool', 'Specifies whether this checkbox belongs to a multivalue (is part of a checkbox group)', false, false);
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $checked = $this->arguments['checked'];
+        $multiple = $this->arguments['multiple'];
+
+        $nameAttribute = $this->getName();
+
+        $valueAttribute = $this->getValueAttribute();
+        $propertyValue = null;
+        if ($this->hasMappingErrorOccurred()) {
+            $propertyValue = $this->getLastSubmittedFormData();
+        }
+        if ($checked === null && $propertyValue === null) {
+            $propertyValue = $this->getPropertyValue();
+        }
+
+        if ($propertyValue instanceof Traversable) {
+            $propertyValue = iterator_to_array($propertyValue);
+        }
+        if (is_array($propertyValue)) {
+            $propertyValue = array_map($this->convertToPlainValue(...), $propertyValue);
+            if ($checked === null) {
+                $checked = in_array($valueAttribute, $propertyValue);
+            }
+            $nameAttribute .= '[]';
+        } elseif ($multiple === true) {
+            $nameAttribute .= '[]';
+        } elseif ($propertyValue !== null) {
+            $checked = (bool)$propertyValue === (bool)$valueAttribute;
+        }
+
+        $this->registerFieldNameForFormTokenGeneration($nameAttribute);
+        $this->data['name'] = $nameAttribute;
+        $this->data['type'] = 'checkbox';
+        $this->data['value'] = $valueAttribute;
+        if ($checked === true) {
+            $this->data['checked'] = 'checked';
+        }
+
+        $this->setErrorClassAttribute();
+        $hiddenField = $this->renderHiddenFieldForEmptyValue();
+        return $hiddenField . json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/CountrySelectViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/CountrySelectViewHelper.php
@@ -1,0 +1,281 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+use TYPO3\CMS\Core\Country\Country;
+use TYPO3\CMS\Core\Country\CountryFilter;
+use TYPO3\CMS\Core\Country\CountryProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Renders a :html:`<select>` tag with all available countries as options.
+ *
+ * Examples
+ * ========
+ *
+ * Basic usage
+ * -----------
+ *
+ * ::
+ *
+ *    <f:form.countrySelect name="country" value="{defaultCountry}" />
+ *
+ * Output::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[country]",
+ *      "type": "countrySelect",
+ *      "value": "{defaultCountry}",
+ *      "options": [
+ *          {
+ *              "value": "AD",
+ *              "label": "Andorra",
+ *              "selected": false
+ *          },
+ *          ...
+ *      ]
+ *    }
+ *
+ * Prioritize countries
+ * --------------------
+ *
+ * Define a list of countries which should be listed as first options in the
+ * form element::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[country]",
+ *      "type": "countrySelect",
+ *      "value": "AT",
+ *      "options": [
+ *          {
+ *              "value": "DE",
+ *              "label": "Germany",
+ *              "selected": false
+ *          },
+ *          {
+ *              "value": "AT",
+ *              "label": "Austria",
+ *              "selected": true
+ *          },
+ *          {
+ *              "value": "CH",
+ *              "label": "Switzerland",
+ *              "selected": false
+ *          },
+ *          {
+ *          "value": "AD",
+ *          "label": "Andorra",
+ *          "selected": false
+ *          },
+ *          ...
+ *      ]
+ *    }
+ *
+ *  Additionally, Austria is pre-selected.
+ *
+ * Display another language
+ * ------------------------
+ *
+ * A combination of optionLabelField and alternativeLanguage is possible. For
+ * instance, if you want to show the localized official names but not in your
+ * default language but in French. You can achieve this by using the following
+ * combination::
+ *
+ *    <f:form.countrySelect
+ *      name="country"
+ *      optionLabelField="localizedOfficialName"
+ *      alternativeLanguage="fr"
+ *      sortByOptionLabel="true"
+ *    />
+ *
+ * Bind an object
+ * --------------
+ *
+ * You can also use the "property" attribute if you have bound an object to the form.
+ * See :ref:`<f:form> <typo3-fluid-form>` for more documentation.
+ */
+final class CountrySelectViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('excludeCountries', 'array', 'Array with country codes that should not be shown.', false, []);
+        $this->registerArgument('onlyCountries', 'array', 'If set, only the country codes in the list are rendered.', false, []);
+        $this->registerArgument('optionLabelField', 'string', 'If specified, will call the appropriate getter on each object to determine the label. Use "name", "localizedName", "officialName" or "localizedOfficialName"', false, 'localizedName');
+        $this->registerArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, false);
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+        $this->registerArgument('prependOptionLabel', 'string', 'If specified, will provide an option at first position with the specified label.');
+        $this->registerArgument('prependOptionValue', 'string', 'If specified, will provide an option at first position with the specified value.');
+        $this->registerArgument('multiple', 'boolean', 'If set multiple options may be selected.', false, false);
+        $this->registerArgument('required', 'boolean', 'If set no empty value is allowed.', false, false);
+        $this->registerArgument('prioritizedCountries', 'array', 'A list of country codes which should be listed on top of the list.', false, []);
+        $this->registerArgument('alternativeLanguage', 'string', 'If specified, the country list will be shown in the given language.');
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        if ($this->arguments['required']) {
+            $this->data['required'] = 'required';
+        }
+        $name = $this->getName();
+        if ($this->arguments['multiple']) {
+            $this->data['multiple'] = 'multiple';
+            $name .= '[]';
+        }
+        $this->addAdditionalIdentityPropertiesIfNeeded();
+        $this->setErrorClassAttribute();
+        $this->registerFieldNameForFormTokenGeneration($name);
+        $this->setRespectSubmittedDataValue(true);
+
+        $this->data['name'] = $name;
+        $this->data['type'] = 'countrySelect';
+
+        $validCountries = $this->getCountryList();
+        $options = $this->createOptions($validCountries);
+        $selectedValue = $this->getValueAttribute();
+
+        if ($selectedValue !== null) {
+            $this->data['value'] = $selectedValue;
+        }
+
+        $prependOptionTag = $this->renderPrependOptionTag();
+        $optionArray = [];
+
+        if (!empty($prependOptionTag)) {
+            $optionArray[] = $prependOptionTag;
+        }
+
+        foreach ($options as $value => $label) {
+            $optionArray[] = $this->renderOptionTag($value, $label, $value === $selectedValue);
+        }
+
+        $this->tag->forceClosingTag(true);
+        $this->data['options'] = $optionArray;
+        return json_encode($this->data);
+    }
+
+    /**
+     * @param Country[] $countries
+     * @return array<string, string>
+     */
+    protected function createOptions(array $countries): array
+    {
+        $options = [];
+        foreach ($countries as $code => $country) {
+            switch ($this->arguments['optionLabelField']) {
+                case 'localizedName':
+                    $options[$code] = $this->translate($country->getLocalizedNameLabel());
+                    break;
+                case 'name':
+                    $options[$code] = $country->getName();
+                    break;
+                case 'officialName':
+                    $options[$code] = $country->getOfficialName();
+                    break;
+                case 'localizedOfficialName':
+                    $name = $this->translate($country->getLocalizedOfficialNameLabel());
+                    if (!$name) {
+                        $name = $this->translate($country->getLocalizedNameLabel());
+                    }
+                    $options[$code] = $name;
+                    break;
+                default:
+                    throw new \TYPO3Fluid\Fluid\Core\ViewHelper\Exception('Argument "optionLabelField" of <f:form.countrySelect> must either be set to "localizedName", "name", "officialName", or "localizedOfficialName".', 1674076708);
+            }
+        }
+        if ($this->arguments['sortByOptionLabel']) {
+            asort($options, SORT_LOCALE_STRING);
+        } else {
+            ksort($options, SORT_NATURAL);
+        }
+        if (($this->arguments['prioritizedCountries'] ?? []) !== []) {
+            $finalOptions = [];
+            foreach ($this->arguments['prioritizedCountries'] as $countryCode) {
+                if (isset($options[$countryCode])) {
+                    $label = $options[$countryCode];
+                    $finalOptions[$countryCode] = $label;
+                    unset($options[$countryCode]);
+                }
+            }
+            foreach ($options as $countryCode => $label) {
+                $finalOptions[$countryCode] = $label;
+            }
+            $options = $finalOptions;
+        }
+        return $options;
+    }
+
+    protected function translate(string $label): string
+    {
+        if ($this->arguments['alternativeLanguage']) {
+            return (string)LocalizationUtility::translate($label, languageKey: $this->arguments['alternativeLanguage']);
+        }
+        return (string)LocalizationUtility::translate($label);
+    }
+
+    /**
+     * Render prepended option tag
+     */
+    protected function renderPrependOptionTag(): array
+    {
+        if ($this->hasArgument('prependOptionLabel')) {
+            $value = $this->hasArgument('prependOptionValue') ? $this->arguments['prependOptionValue'] : '';
+            $label = $this->arguments['prependOptionLabel'];
+            return $this->renderOptionTag((string)$value, (string)$label, false);
+        }
+        return [];
+    }
+
+    /**
+     * Render one option tag
+     *
+     * @param string $value value attribute of the option tag (will be escaped)
+     * @param string $label content of the option tag (will be escaped)
+     * @param bool $isSelected specifies whether to add selected attribute
+     * @return array the rendered option tag
+     */
+    protected function renderOptionTag(string $value, string $label, bool $isSelected): array
+    {
+        return [
+            'value' => $value,
+            'label' => $label,
+            'selected' => $isSelected,
+        ];
+    }
+
+    /**
+     * @return Country[]
+     */
+    protected function getCountryList(): array
+    {
+        $filter = new CountryFilter();
+        $filter->setOnlyCountries($this->arguments['onlyCountries'] ?? [])
+            ->setExcludeCountries($this->arguments['excludeCountries'] ?? []);
+        return GeneralUtility::makeInstance(CountryProvider::class)->getFiltered($filter);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/HiddenViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/HiddenViewHelper.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * Renders an :html:`<input type="hidden" ...>` tag.
+ *
+ * Examples
+ * ========
+ *
+ * Example::
+ *
+ *    <f:form.hidden name="myHiddenValue" value="42" />
+ *
+ * Output::
+ *
+ *    {
+ *       "type": "hidden",
+ *       "name": "tx_extension_plugin[myHiddenValue]",
+ *       "value": 42
+ *    }
+ *
+ * You can also use the "property" attribute if you have bound an object to the form.
+ * See :ref:`<f:form> <typo3-fluid-form>` for more documentation.
+ */
+final class HiddenViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument(
+            'respectSubmittedDataValue',
+            'bool',
+            'enable or disable the usage of the submitted values',
+            false,
+            true
+        );
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $name = $this->getName();
+        $this->registerFieldNameForFormTokenGeneration($name);
+        $this->setRespectSubmittedDataValue($this->arguments['respectSubmittedDataValue']);
+
+        $this->data['type'] = 'hidden';
+        $this->data['name'] = $name;
+        $this->data['value'] = $this->getValueAttribute();
+
+        $this->addAdditionalIdentityPropertiesIfNeeded();
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/PasswordViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/PasswordViewHelper.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * ViewHelper which creates a simple Password Text Box :html:`<input type="password">`.
+ *
+ * Examples
+ * ========
+ *
+ * Example::
+ *
+ *    <f:form.password name="myPassword" />
+ *
+ * Output::
+ *
+ *    {
+ *       "type": "password",
+ *       "name": "tx_extension_plugin[myPassword]"
+ *    }
+ */
+final class PasswordViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $name = $this->getName();
+        $this->registerFieldNameForFormTokenGeneration($name);
+        $this->setRespectSubmittedDataValue(true);
+
+        $this->data['type'] = 'password';
+        $this->data['name'] = $name;
+        $this->data['value'] = $this->getValueAttribute();
+
+        $this->addAdditionalIdentityPropertiesIfNeeded();
+        $this->setErrorClassAttribute();
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/RadioViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/RadioViewHelper.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * ViewHelper which creates a simple radio button :html:`<input type="radio">`.
+ *
+ * Examples
+ * ========
+ *
+ * Simple
+ * ------
+ *
+ * ::
+ *
+ *    <f:form.radio name="myRadioButton" value="someValue" />
+ *
+ * Output::
+ *
+ *    {
+ *      "type": "radio",
+ *      "name": "tx_extension_plugin[myRadioButton]",
+ *      "value": "someValue"
+ *    }
+ *
+ * Preselect
+ * ---------
+ *
+ * ::
+ *
+ *    <f:form.radio name="myRadioButton" value="someValue" checked="{object.value} == 5" />
+ *
+ * Output::
+ *
+ *    {
+ *       "type": "radio",
+ *       "name": "tx_extension_plugin[myRadioButton]",
+ *       "value": "someValue"
+ *       "checked: "checked"
+ *    }
+ *
+ * Depending on bound ``object`` to surrounding :ref:`f:form <typo3-fluid-form>`.
+ *
+ * Bind to object property
+ * -----------------------
+ *
+ * ::
+ *
+ *    <f:form.radio property="newsletter" value="1" /> yes
+ *    <f:form.radio property="newsletter" value="0" /> no
+ *
+ * Output::
+ *
+ *    {
+ *      "type": "radio",
+ *      "name": "tx_extension_plugin[user][newsletter]",
+ *      "value": 1,
+ *      "checked": "checked"
+ *    },
+ *    {
+ *      "type": "radio",
+ *      "name": "tx_extension_plugin[user][newsletter]",
+ *      "value": 0
+ *    }
+ *
+ * Depending on property ``newsletter``.
+ */
+final class RadioViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+        $this->registerArgument('checked', 'bool', 'Specifies that the input element should be preselected');
+        $this->registerArgument('value', 'string', 'Value of input tag. Required for radio buttons', true);
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $checked = $this->arguments['checked'];
+
+        $this->data['type'] = 'radio';
+
+        $nameAttribute = $this->getName();
+        $valueAttribute = $this->getValueAttribute();
+
+        $propertyValue = null;
+        if ($this->hasMappingErrorOccurred()) {
+            $propertyValue = $this->getLastSubmittedFormData();
+        }
+        if ($checked === null && $propertyValue === null) {
+            $propertyValue = $this->getPropertyValue();
+            $propertyValue = $this->convertToPlainValue($propertyValue);
+        }
+
+        if ($propertyValue !== null) {
+            // no type-safe comparison by intention
+            $checked = $propertyValue == $valueAttribute;
+        }
+
+        $this->registerFieldNameForFormTokenGeneration($nameAttribute);
+        $this->data['name'] = $nameAttribute;
+        $this->data['value'] = $valueAttribute;
+        if ($checked === true) {
+            $this->data['checked'] = 'checked';
+        }
+
+        $this->setErrorClassAttribute();
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/Select/OptgroupViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/Select/OptgroupViewHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\Select;
+
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\AbstractFormFieldViewHelper;
+
+/**
+ * Adds custom :html:`<optgroup>` tags inside an :ref:`<f:form.select> <typo3-fluid-form-select>`,
+ * supports further child :ref:`<f:form.select.option> <typo3-fluid-form-select-option>` tags.
+ */
+final class OptgroupViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.');
+        $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.');
+        $this->registerArgument('disabled', 'boolean', 'If true, option group is rendered as disabled', false, false);
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $this->data['type'] = 'selectOptionGroup';
+
+        if ($this->arguments['disabled']) {
+            $this->data['disabled'] = 'disabled';
+        }
+
+        $renderedChildren = trim($this->renderChildren());
+        $renderedChildren = preg_replace('!}\s*{!', '},{', $renderedChildren);
+        $renderedChildren = preg_replace("!\r?\n!", '', $renderedChildren);
+        $renderedChildren = '{"elements": [' . $renderedChildren . ']}';
+        $renderedChildren = json_decode($renderedChildren, true);
+
+        if ($renderedChildren !== null) {
+            $this->data['options'] = $renderedChildren['elements'];
+        }
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\Select;
+
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\AbstractFormFieldViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\SelectViewHelper;
+use Iterator;
+
+/**
+ * Adds custom :html:`<option>` tags inside an :ref:`<f:form.select> <typo3-fluid-form-select>`.
+ */
+final class OptionViewHelper extends AbstractFormFieldViewHelper
+{
+    /**
+     * @var string
+     */
+    protected $tagName = 'option';
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('selected', 'boolean', 'If set, overrides automatic detection of selected state for this option.');
+        $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.');
+        $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.');
+        $this->registerArgument('value', 'mixed', 'Value to be inserted in HTML tag - must be convertible to string!');
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $childContent = $this->renderChildren();
+        $this->data['content'] = (string)$childContent;
+        $value = $this->arguments['value'] ?? $childContent;
+        if ($this->arguments['selected'] ?? $this->isValueSelected((string)$value)) {
+            $this->data['selected'] = 'selected';
+        }
+        $this->data['value'] = $value;
+        $this->data['type'] = 'selectOption';
+        $parentRequestedFormTokenFieldName = $this->renderingContext->getViewHelperVariableContainer()->get(
+            SelectViewHelper::class,
+            'registerFieldNameForFormTokenGeneration'
+        );
+        if ($parentRequestedFormTokenFieldName) {
+            // parent (select field) has requested this option must add one more
+            // entry in the token generation registry for one additional potential
+            // value of the field. Happens when "multiple" is true on parent.
+            $this->registerFieldNameForFormTokenGeneration($parentRequestedFormTokenFieldName);
+        }
+        return json_encode($this->data);
+    }
+
+    protected function isValueSelected(string $value): bool
+    {
+        $selectedValue = $this->renderingContext->getViewHelperVariableContainer()->get(SelectViewHelper::class, 'selectedValue');
+        if (is_array($selectedValue)) {
+            return in_array($value, array_map(strval(...), $selectedValue), true);
+        }
+        if ($selectedValue instanceof Iterator) {
+            return in_array($value, array_map(strval(...), iterator_to_array($selectedValue)), true);
+        }
+        return $value === (string)$selectedValue;
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/SelectViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/SelectViewHelper.php
@@ -1,0 +1,401 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+use BackedEnum;
+use InvalidArgumentException;
+use Traversable;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use UnitEnum;
+
+/**
+ * This ViewHelper generates a :html:`<select>` dropdown list for the use with a form.
+ *
+ * Basic usage
+ * ===========
+ *
+ * The most straightforward way is to supply an associative array as the ``options`` parameter.
+ * The array key is used as option key, and the value is used as human-readable name.
+ *
+ * Basic usage::
+ *
+ *    <f:form.select name="paymentOptions" options="{payPal: 'PayPal International Services', visa: 'VISA Card'}" />
+ *
+ * Pre select a value
+ * ------------------
+ *
+ * To pre select a value, set ``value`` to the option key which should be selected.
+ * Default value::
+ *
+ *    <f:form.select name="paymentOptions" options="{payPal: 'PayPal International Services', visa: 'VISA Card'}" value="visa" />
+ *
+ * Generates a dropdown box like above, except that "VISA Card" is selected.
+ *
+ * If the select box is a multi-select box :html:`multiple="1"`, then "value" can be an array as well.
+ *
+ * Custom options and option group rendering
+ * -----------------------------------------
+ *
+ * Child nodes can be used to create a completely custom set of
+ * :html:`<option>` and :html:`<optgroup>` tags in a way compatible with the
+ * HMAC generation.
+ * To do so, leave out the ``options`` argument and use child ViewHelpers:
+ *
+ * Custom options and optgroup::
+ *
+ *    <f:form.select name="myproperty">
+ *       <f:form.select.option value="1">Option one</f:form.select.option>
+ *       <f:form.select.option value="2">Option two</f:form.select.option>
+ *       <f:form.select.optgroup>
+ *          <f:form.select.option value="3">Grouped option one</f:form.select.option>
+ *          <f:form.select.option value="4">Grouped option twi</f:form.select.option>
+ *       </f:form.select.optgroup>
+ *    </f:form.select>
+ *
+ * .. note::
+ *    Do not use vanilla :html:`<option>` or :html:`<optgroup>` tags!
+ *    They will invalidate the HMAC generation!
+ *
+ * Usage on domain objects
+ * -----------------------
+ *
+ * If you want to output domain objects, you can just pass them as array into the ``options`` parameter.
+ * To define what domain object value should be used as option key, use the ``optionValueField`` variable. Same goes for ``optionLabelField``.
+ * If neither is given, the Identifier (UID/uid) and the :php:`__toString()` method are tried as fallbacks.
+ *
+ * If the ``optionValueField`` variable is set, the getter named after that value is used to retrieve the option key.
+ * If the ``optionLabelField`` variable is set, the getter named after that value is used to retrieve the option value.
+ *
+ * If the ``prependOptionLabel`` variable is set, an option item is added in first position, bearing an empty string or -
+ * if provided, the value of the ``prependOptionValue`` variable as value.
+ *
+ * Domain objects::
+ *
+ *    <f:form.select name="users" options="{userArray}" optionValueField="id" optionLabelField="firstName" />
+ *
+ * In the above example, the ``userArray`` is an array of "User" domain objects, with no array key specified.
+ *
+ * So, in the above example, the method :php:`$user->getId()` is called to
+ * retrieve the key, and :php:`$user->getFirstName()` to retrieve the displayed
+ * value of each entry.
+ *
+ * The ``value`` property now expects a domain object, and tests for object equivalence.
+ */
+final class SelectViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('options', 'array', 'Associative array with internal IDs as key, and the values are displayed in the select box. Can be combined with or replaced by child f:form.select.* nodes.');
+        $this->registerArgument('optionsAfterContent', 'boolean', 'If true, places auto-generated option tags after those rendered in the tag content. If false, automatic options come first.', false, false);
+        $this->registerArgument('optionValueField', 'string', 'If specified, will call the appropriate getter on each object to determine the value.');
+        $this->registerArgument('optionLabelField', 'string', 'If specified, will call the appropriate getter on each object to determine the label.');
+        $this->registerArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, false);
+        $this->registerArgument('selectAllByDefault', 'boolean', 'If specified options are selected if none was set before.', false, false);
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+        $this->registerArgument('prependOptionLabel', 'string', 'If specified, will provide an option at first position with the specified label.');
+        $this->registerArgument('prependOptionValue', 'string', 'If specified, will provide an option at first position with the specified value.');
+        $this->registerArgument('multiple', 'boolean', 'If set multiple options may be selected.', false, false);
+        $this->registerArgument('required', 'boolean', 'If set no empty value is allowed.', false, false);
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        if ($this->arguments['required']) {
+            $this->data['required'] = 'required';
+        }
+        $name = $this->getName();
+        if ($this->arguments['multiple']) {
+            $this->data['multiple'] = 'multiple';
+            $name .= '[]';
+        }
+        $this->data['name'] = $name;
+        $this->data['type'] = 'select';
+        $options = $this->getOptions();
+
+        $viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
+
+        $this->addAdditionalIdentityPropertiesIfNeeded();
+        $this->setErrorClassAttribute();
+        $content = '';
+
+        // register field name for token generation.
+        $this->registerFieldNameForFormTokenGeneration($name);
+        // in case it is a multi-select, we need to register the field name
+        // as often as there are elements in the box
+        if ($this->arguments['multiple']) {
+            $content .= $this->renderHiddenFieldForEmptyValue();
+            // Register the field name additional times as required by the total number of
+            // options. Since we already registered it once above, we start the counter at 1
+            // instead of 0.
+            $optionsCount = count($options);
+            for ($i = 1; $i < $optionsCount; $i++) {
+                $this->registerFieldNameForFormTokenGeneration($name);
+            }
+            // save the parent field name so that any child f:form.select.option
+            // tag will know to call registerFieldNameForFormTokenGeneration
+            // this is the reason why "self::class" is used instead of static::class (no LSB)
+            $viewHelperVariableContainer->addOrUpdate(
+                self::class,
+                'registerFieldNameForFormTokenGeneration',
+                $name
+            );
+        }
+
+        $selectedValue = $this->getSelectedValue();
+
+        $viewHelperVariableContainer->addOrUpdate(self::class, 'selectedValue', $selectedValue);
+        if ($selectedValue !== null) {
+            $this->data['value'] = $selectedValue;
+        }
+
+        $optionArray = [];
+        $prependContent = $this->renderPrependOptionTag();
+        if (!empty($prependContent)) {
+            $optionArray[] = $prependContent;
+        }
+
+        $renderedOptions = $this->renderOptionTags($options);
+
+        $renderedChildren = $this->renderChildren();
+
+        $childContent = [];
+        if ($renderedChildren !== null) {
+            $renderedChildren = trim($renderedChildren);
+            $renderedChildren = preg_replace('!}\s*{!', '},{', $renderedChildren);
+            $renderedChildren = preg_replace("!\r?\n!", '', $renderedChildren);
+            $renderedChildren = '{"elements": [' . $renderedChildren . ']}';
+            $renderedChildren = json_decode($renderedChildren, true);
+            $childContent = $renderedChildren['elements'];
+        }
+
+        $viewHelperVariableContainer->remove(self::class, 'selectedValue');
+        $viewHelperVariableContainer->remove(self::class, 'registerFieldNameForFormTokenGeneration');
+        if (!empty($childContent)) {
+            if (isset($this->arguments['optionsAfterContent']) && $this->arguments['optionsAfterContent']) {
+                $optionArray[] = $childContent;
+                if (!empty($renderedOptions)) {
+                    $optionArray[] = $renderedOptions;
+                }
+            } else {
+                if (!empty($renderedOptions)) {
+                    $optionArray[] = $renderedOptions;
+                }
+
+                $optionArray[] = $childContent;
+            }
+        } else {
+            $optionArray[] = $renderedOptions;
+        }
+
+        $this->tag->forceClosingTag(true);
+        $this->data['options'] = $optionArray;
+        return json_encode($this->data);
+    }
+
+    /**
+     * Render prepended option tag
+     */
+    protected function renderPrependOptionTag(): array
+    {
+        if ($this->hasArgument('prependOptionLabel')) {
+            $value = $this->hasArgument('prependOptionValue') ? $this->arguments['prependOptionValue'] : '';
+            $label = $this->arguments['prependOptionLabel'];
+            return $this->renderOptionTag((string)$value, (string)$label, false);
+        }
+        return [];
+    }
+
+    /**
+     * Render the option tags.
+     */
+    protected function renderOptionTags(array $options): array
+    {
+        $optionArray = [];
+        foreach ($options as $value => $label) {
+            $isSelected = $this->isSelected($value);
+            $optionArray[] = $this->renderOptionTag((string)$value, (string)$label, $isSelected);
+        }
+        return $optionArray;
+    }
+
+    /**
+     * Render the option tags.
+     *
+     * @return array An associative array of options, key will be the value of the option tag
+     */
+    protected function getOptions(): array
+    {
+        if (!is_array($this->arguments['options']) && !$this->arguments['options'] instanceof Traversable) {
+            return [];
+        }
+        $options = [];
+        $optionsArgument = $this->arguments['options'];
+        foreach ($optionsArgument as $key => $value) {
+            if (!is_object($value) && !is_array($value)) {
+                $options[$key] = $value;
+                continue;
+            }
+            if (is_array($value)) {
+                if (!$this->hasArgument('optionValueField')) {
+                    throw new InvalidArgumentException('Missing parameter "optionValueField" in SelectViewHelper for array value options.', 1682693720);
+                }
+                if (!$this->hasArgument('optionLabelField')) {
+                    throw new InvalidArgumentException('Missing parameter "optionLabelField" in SelectViewHelper for array value options.', 1682693721);
+                }
+                $key = ObjectAccess::getPropertyPath($value, $this->arguments['optionValueField']);
+                $value = ObjectAccess::getPropertyPath($value, $this->arguments['optionLabelField']);
+                $options[$key] = $value;
+                continue;
+            }
+            if ($this->hasArgument('optionValueField')) {
+                $key = ObjectAccess::getPropertyPath($value, $this->arguments['optionValueField']);
+                if (is_object($key)) {
+                    if (method_exists($key, '__toString')) {
+                        $key = (string)$key;
+                    } else {
+                        throw new Exception('Identifying value for object of class "' . get_debug_type($value) . '" was an object.', 1247827428);
+                    }
+                }
+            } elseif ($this->persistenceManager->getIdentifierByObject($value) !== null) {
+                // @todo use $this->persistenceManager->isNewObject() once it is implemented
+                $key = $this->persistenceManager->getIdentifierByObject($value);
+            } elseif (is_object($value) && method_exists($value, '__toString')) {
+                $key = (string)$value;
+            } elseif (is_object($value)) {
+                throw new Exception('No identifying value for object of class "' . get_class($value) . '" found.', 1247826696);
+            }
+            if ($this->hasArgument('optionLabelField')) {
+                $value = ObjectAccess::getPropertyPath($value, $this->arguments['optionLabelField']);
+                if (is_object($value)) {
+                    if (method_exists($value, '__toString')) {
+                        $value = (string)$value;
+                    } else {
+                        throw new Exception('Label value for object of class "' . get_class($value) . '" was an object without a __toString() method.', 1247827553);
+                    }
+                }
+            } elseif (is_object($value) && method_exists($value, '__toString')) {
+                $value = (string)$value;
+            } elseif ($this->persistenceManager->getIdentifierByObject($value) !== null) {
+                // @todo use $this->persistenceManager->isNewObject() once it is implemented
+                $value = $this->persistenceManager->getIdentifierByObject($value);
+            }
+            $options[$key] = $value;
+        }
+        if ($this->arguments['sortByOptionLabel']) {
+            asort($options, SORT_LOCALE_STRING);
+        }
+        return $options;
+    }
+
+    /**
+     * Render the option tags.
+     *
+     * @param mixed $value Value to check for
+     * @return bool True if the value should be marked as selected.
+     */
+    protected function isSelected($value): bool
+    {
+        $selectedValue = $this->getSelectedValue();
+        if ($value === $selectedValue || (string)$value === $selectedValue) {
+            return true;
+        }
+        if ($this->hasArgument('multiple')) {
+            if ($selectedValue === null && $this->arguments['selectAllByDefault'] === true) {
+                return true;
+            }
+            if (is_array($selectedValue) && in_array($value, $selectedValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves the selected value(s)
+     *
+     * @return mixed value string or an array of strings
+     */
+    protected function getSelectedValue()
+    {
+        $this->setRespectSubmittedDataValue(true);
+        $value = $this->getValueAttribute();
+        if (!is_array($value) && !$value instanceof Traversable) {
+            return $this->getOptionValueScalar($value);
+        }
+        $selectedValues = [];
+        foreach ($value as $selectedValueElement) {
+            $selectedValues[] = $this->getOptionValueScalar($selectedValueElement);
+        }
+        return $selectedValues;
+    }
+
+    /**
+     * Get the option value for an object
+     *
+     * @param mixed $valueElement
+     * @return string @todo: Does not always return string ...
+     */
+    protected function getOptionValueScalar($valueElement)
+    {
+        if (is_object($valueElement)) {
+            if ($this->hasArgument('optionValueField')) {
+                return ObjectAccess::getPropertyPath($valueElement, $this->arguments['optionValueField']);
+            }
+            // @todo use $this->persistenceManager->isNewObject() once it is implemented
+            if ($this->persistenceManager->getIdentifierByObject($valueElement) !== null) {
+                return $this->persistenceManager->getIdentifierByObject($valueElement);
+            }
+            if ($valueElement instanceof BackedEnum) {
+                return $valueElement->value;
+            }
+            if ($valueElement instanceof UnitEnum) {
+                return $valueElement->name;
+            }
+            return (string)$valueElement;
+        }
+        return $valueElement;
+    }
+
+    /**
+     * Render one option tag
+     *
+     * @param string $value value attribute of the option tag (will be escaped)
+     * @param string $label content of the option tag (will be escaped)
+     * @param bool $isSelected specifies whether to add selected attribute
+     * @return array the rendered option tag
+     */
+    protected function renderOptionTag(string $value, string $label, bool $isSelected): array
+    {
+        return [
+            'value' => htmlspecialchars($value),
+            'label' => htmlspecialchars($label),
+            'selected' => $isSelected,
+        ];
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/SubmitViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/SubmitViewHelper.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * Creates a submit button.
+ *
+ * Examples
+ * ========
+ *
+ * Defaults
+ * --------
+ *
+ * ::
+ *
+ *    <f:form.submit value="Send Mail" />
+ *
+ * Output::
+ *
+ *    {
+ *      "type": "submit",
+ *      "value": "Send Mail"
+ *    }
+ *
+ * Dummy content for template preview
+ * ----------------------------------
+ *
+ * ::
+ *
+ *    <f:form.submit name="mySubmit" value="Send Mail"><button>dummy button</button></f:form.submit>
+ *
+ * Output::
+ *
+ *    <input type="submit" name="mySubmit" value="Send Mail" />
+ */
+final class SubmitViewHelper extends AbstractFormFieldViewHelper
+{
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $name = $this->getName();
+        $this->registerFieldNameForFormTokenGeneration($name);
+
+        $this->data['type'] = 'submit';
+        $this->data['value'] = $this->getValueAttribute();
+        if (!empty($name)) {
+            $this->data['name'] = $name;
+        }
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/TextareaViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/TextareaViewHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * Generates an :html:`<textarea>`.
+ *
+ * The value of the text area needs to be set via the ``value`` attribute, as with all other form ViewHelpers.
+ *
+ * Examples
+ * ========
+ *
+ * Example::
+ *
+ *    <f:form.textarea name="myTextArea" value="This is shown inside the textarea" />
+ *
+ * Output::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[myTextArea]",
+ *      "type": "textarea",
+ *      "value": "This is shown inside the textarea"
+ *    }
+ */
+final class TextareaViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+        $this->registerArgument('required', 'bool', 'Specifies whether the textarea is required', false, false);
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $required = $this->arguments['required'];
+        $name = $this->getName();
+        $this->registerFieldNameForFormTokenGeneration($name);
+        $this->setRespectSubmittedDataValue(true);
+
+        $this->data['name'] = $name;
+        $this->data['type'] = 'textarea';
+        if ($required === true) {
+            $this->data['required'] = 'required';
+        }
+
+        $this->data['value'] = htmlspecialchars((string)$this->getValueAttribute());
+        $this->addAdditionalIdentityPropertiesIfNeeded();
+        $this->setErrorClassAttribute();
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/TextfieldViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/TextfieldViewHelper.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * ViewHelper which creates a text field :html:`<input type="text">`.
+ *
+ * Examples
+ * ========
+ *
+ * Example::
+ *
+ *    <f:form.textfield name="myTextBox" value="default value" />
+ *
+ * Output::
+ *
+ *    {
+ *      "name": "tx_extension_plugin[myTextBox]",
+ *      "type": "text",
+ *      "value": "default value"
+ *    }
+ */
+final class TextfieldViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+        $this->registerArgument('required', 'bool', 'If the field is required or not', false, false);
+        $this->registerArgument('type', 'string', 'The field type, e.g. "text", "email", "url" etc.', false, 'text');
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $required = $this->arguments['required'];
+        $type = $this->arguments['type'];
+
+        $name = $this->getName();
+        $this->registerFieldNameForFormTokenGeneration($name);
+        $this->setRespectSubmittedDataValue(true);
+
+        $this->data['name'] = $name;
+        $this->data['type'] = $type;
+
+        $value = $this->getValueAttribute();
+
+        if ($value !== null) {
+            $this->data['value'] = $value;
+        }
+
+        if ($required !== false) {
+            $this->data['required'] = $required;
+            $this->tag->addAttribute('required', 'required');
+        }
+
+        $this->addAdditionalIdentityPropertiesIfNeeded();
+        $this->setErrorClassAttribute();
+
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/Form/UploadViewHelper.php
+++ b/Classes/XClass/ViewHelpers/Form/UploadViewHelper.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form;
+
+/**
+ * A ViewHelper which generates an :html:`<input type="file">` HTML element.
+ * Make sure to set ``enctype="multipart/form-data"`` on the form!
+ *
+ * Examples
+ * ========
+ *
+ * Example::
+ *
+ *    <f:form.upload name="file" />
+ *
+ * Output::
+ *
+ *    {
+ *      "type": "file",
+ *      "name": "tx_extension_plugin[file]"
+ *    }
+ */
+final class UploadViewHelper extends AbstractFormFieldViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+    }
+
+    public function render(): string
+    {
+        $this->data = json_decode(parent::render(), true);
+
+        $multiple = isset($this->additionalArguments['multiple']);
+        $name = $this->getName();
+        $allowedFields = ['name', 'type', 'tmp_name', 'error', 'size'];
+        foreach ($allowedFields as $fieldName) {
+            if ($multiple) {
+                $formTokenFieldName = sprintf('%s[*][%s]', $name, $fieldName);
+            } else {
+                $formTokenFieldName = $name . '[' . $fieldName . ']';
+            }
+            $this->registerFieldNameForFormTokenGeneration($formTokenFieldName);
+        }
+        $this->data['type'] = 'file';
+
+        if ($multiple) {
+            $this->data['name'] = $name . '[]';
+        } else {
+            $this->data['name'] = $name;
+        }
+
+        $this->setErrorClassAttribute();
+        return json_encode($this->data);
+    }
+}

--- a/Classes/XClass/ViewHelpers/FormViewHelper.php
+++ b/Classes/XClass/ViewHelpers/FormViewHelper.php
@@ -1,0 +1,239 @@
+<?php
+
+/*
+ * This file is part of the "headless" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+namespace FriendsOfTYPO3\Headless\XClass\ViewHelpers;
+
+use LogicException;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
+use TYPO3\CMS\Extbase\Mvc\RequestInterface;
+use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
+use TYPO3\CMS\Extbase\Security\HashScope;
+
+class FormViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
+{
+    protected array $data = [];
+
+    public function render(): string
+    {
+        foreach ($this->tag->getAttributes() as $key => $value) {
+            if (str_starts_with($key, 'data-')) {
+                $key = substr($key, strpos('data-', $key) + 5);
+                $this->data['data'][$key] = $value;
+                continue;
+            }
+
+            $this->data[$key] = $value;
+        }
+
+        if (!$this->renderingContext->hasAttribute(ServerRequestInterface::class)
+            || !$this->renderingContext->getAttribute(ServerRequestInterface::class) instanceof RequestInterface) {
+            throw new RuntimeException(
+                'ViewHelper f:form can be used only in extbase context and needs a request implementing extbase RequestInterface.',
+                1639821904
+            );
+        }
+
+        $this->setFormActionUri();
+
+        if ($this->tag->getAttribute('action') !== null) {
+            $this->data['action'] = $this->tag->getAttribute('action');
+        }
+
+        // Force 'method="get"' or 'method="post"', defaulting to "post".
+        if (isset($this->arguments['method']) && strtolower($this->arguments['method']) === 'get') {
+            $this->data['method'] = 'get';
+        } else {
+            $this->data['method'] = 'post';
+        }
+
+        if (!empty($this->arguments['name'])) {
+            $this->data['name'] = $this->arguments['name'];
+        }
+
+        if (isset($this->arguments['novalidate']) && $this->arguments['novalidate'] === true) {
+            $this->data['novalidate'] = 'novalidate';
+        }
+
+        $this->addFormObjectNameToViewHelperVariableContainer();
+        $this->addFormObjectToViewHelperVariableContainer();
+        $this->addFieldNamePrefixToViewHelperVariableContainer();
+        $this->addFormFieldNamesToViewHelperVariableContainer();
+
+        $children = trim($this->renderChildren());
+        $children = preg_replace('!}\s*{!', '},{', $children);
+        $children = preg_replace("!\r?\n!", '', $children);
+        $children = '{"elements": [' . $children . ']}';
+        $children = json_decode($children, true);
+
+        if ($children !== null && isset($children['elements'])) {
+            $this->data['elements'] = $children['elements'];
+        }
+
+        if (isset($this->arguments['hiddenFieldClassName']) && $this->arguments['hiddenFieldClassName'] !== null) {
+            $this->data['hiddenFieldClassName'] = htmlspecialchars($this->arguments['hiddenFieldClassName']);
+        }
+
+        $this->renderHiddenIdentityField($this->arguments['object'] ?? null, $this->getFormObjectName());
+        $this->renderAdditionalIdentityFields();
+        $this->renderHiddenReferrerFields();
+        $this->renderRequestTokenHiddenField();
+
+        // Render the trusted list of all properties after everything else has been rendered
+        $this->renderTrustedPropertiesField();
+
+        //$content .= $formContent;
+        $this->removeFieldNamePrefixFromViewHelperVariableContainer();
+        $this->removeFormObjectFromViewHelperVariableContainer();
+        $this->removeFormObjectNameFromViewHelperVariableContainer();
+        $this->removeFormFieldNamesFromViewHelperVariableContainer();
+        $this->removeCheckboxFieldNamesFromViewHelperVariableContainer();
+
+        return json_encode($this->data);
+    }
+
+    /**
+     * Render the request hash field
+     */
+    protected function renderTrustedPropertiesField(): string
+    {
+        $formFieldNames = $this->renderingContext->getViewHelperVariableContainer()->get(\TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper::class, 'formFieldNames');
+        $requestHash = $this->mvcPropertyMappingConfigurationService->generateTrustedPropertiesToken($formFieldNames, $this->getFieldNamePrefix());
+
+        $this->addHiddenField('__trustedProperties', $requestHash);
+
+        return '';
+    }
+
+    /**
+     * Renders a hidden form field containing the technical identity of the given object.
+     *
+     * @param mixed $object Object to create the identity field for. Non-objects are ignored.
+     * @param string|null $name Name
+     * @return string A hidden field containing the Identity (uid) of the given object
+     * @see \TYPO3\CMS\Extbase\Mvc\Controller\Argument::setValue()
+     */
+    protected function renderHiddenIdentityField(mixed $object, ?string $name): string
+    {
+        if ($object instanceof LazyLoadingProxy) {
+            $object = $object->_loadRealInstance();
+        }
+        if (!is_object($object)
+            || !($object instanceof AbstractDomainObject)
+            || ($object->_isNew() && !$object->_isClone())) {
+            return '';
+        }
+        // Intentionally NOT using PersistenceManager::getIdentifierByObject here.
+        // Using that one breaks re-submission of data in forms in case of an error.
+        $identifier = $object->getUid();
+        if ($identifier === null) {
+            return '';
+        }
+        $name = $this->prefixFieldName($name ?? '') . '[__identity]';
+        $this->registerFieldNameForFormTokenGeneration($name);
+
+        $this->addHiddenField($name, $identifier);
+
+        return '';
+    }
+
+    protected function renderRequestTokenHiddenField(): string
+    {
+        $requestToken = $this->arguments['requestToken'] ?? null;
+        $signingType = $this->arguments['signingType'] ?? null;
+
+        $isTrulyRequestToken = is_int($requestToken) && $requestToken === 1
+            || is_string($requestToken) && strtolower($requestToken) === 'true';
+        $formAction = $this->tag->getAttribute('action');
+
+        // basically "request token, yes" - uses form-action URI as scope
+        if ($isTrulyRequestToken || $requestToken === '@nonce') {
+            $requestToken = RequestToken::create($formAction);
+            // basically "request token with 'my-scope'" - uses 'my-scope'
+        } elseif (is_string($requestToken) && $requestToken !== '') {
+            $requestToken = RequestToken::create($requestToken);
+        }
+        if (!$requestToken instanceof RequestToken) {
+            return '';
+        }
+        if (strtolower((string)($this->arguments['method'] ?? '')) === 'get') {
+            throw new LogicException('Cannot apply request token for forms sent via HTTP GET', 1651775963);
+        }
+
+        $context = GeneralUtility::makeInstance(Context::class);
+        $securityAspect = SecurityAspect::provideIn($context);
+        // @todo currently defaults to 'nonce', there might be a better strategy in the future
+        $signingType = $signingType ?: 'nonce';
+        $signingProvider = $securityAspect->getSigningSecretResolver()->findByType($signingType);
+        if ($signingProvider === null) {
+            throw new LogicException(sprintf('Cannot find request token signing type "%s"', $signingType), 1664260307);
+        }
+
+        $signingSecret = $signingProvider->provideSigningSecret();
+        $requestToken = $requestToken->withMergedParams(['request' => ['uri' => $formAction]]);
+
+        $this->addHiddenField(RequestToken::PARAM_NAME, $requestToken->toHashSignedJwt($signingSecret));
+
+        return '';
+    }
+
+    /**
+     * Render additional identity fields which were registered by form elements.
+     * This happens if a form field is defined like property="bla.blubb" - then we might need an identity property for the sub-object "bla".
+     *
+     * @return string HTML-string for the additional identity properties
+     */
+    protected function renderAdditionalIdentityFields(): string
+    {
+        if ($this->viewHelperVariableContainer->exists(\TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper::class, 'additionalIdentityProperties')) {
+            $additionalIdentityProperties = $this->viewHelperVariableContainer->get(FormViewHelper::class, 'additionalIdentityProperties');
+            foreach ($additionalIdentityProperties as $identity) {
+                $this->addHiddenField('identity', $identity);
+            }
+        }
+
+        return '';
+    }
+
+    protected function renderHiddenReferrerFields(): string
+    {
+        /** @var RequestInterface $request */
+        $request = $this->renderingContext->getAttribute(ServerRequestInterface::class);
+        $extensionName = $request->getControllerExtensionName();
+        $controllerName = $request->getControllerName();
+        $actionName = $request->getControllerActionName();
+        $actionRequest = [
+            '@extension' => $extensionName,
+            '@controller' => $controllerName,
+            '@action' => $actionName,
+        ];
+
+        $this->addHiddenField('__referrer[@extension]', htmlspecialchars($extensionName));
+        $this->addHiddenField('__referrer[@controller]', htmlspecialchars($controllerName));
+        $this->addHiddenField('__referrer[@action]', htmlspecialchars($actionName));
+        $this->addHiddenField('__referrer[arguments]', htmlspecialchars($this->hashService->appendHmac(base64_encode(serialize($request->getArguments())), HashScope::ReferringArguments->prefix())));
+        $this->addHiddenField('__referrer[@request]', htmlspecialchars($this->hashService->appendHmac(json_encode($actionRequest), HashScope::ReferringRequest->prefix())));
+
+        return '';
+    }
+
+    protected function addHiddenField(string $name, mixed $value): void
+    {
+        $tmp = [];
+        $tmp['name'] = $name;
+        $tmp['type'] = 'hidden';
+        $tmp['value'] = $value;
+        $this->data['elements'][] = $tmp;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you have any questions just drop a line in #initiative-headless-pwa Slack cha
 - JSON API for content elements
 - JSON API for page and meta data
 - JSON API for navigation, layouts
+- JSON API for Fluid form viewhelpers
 - taking into account all language and translation configuration (e.g. fallback)
 - easily extendable with custom fields or custom content elements
 - custom data processors directly for headless usage

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,6 +30,34 @@ use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\CMS\FrontendLogin\Controller\LoginController;
 use TYPO3\CMS\Workspaces\Controller\PreviewController;
 use TYPO3\CMS\Workspaces\Preview\PreviewUriBuilder;
+use TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\TextfieldViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\TextareaViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\ButtonViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\CheckboxViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\CountrySelectViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\HiddenViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\PasswordViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\RadioViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\SelectViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\Select\OptgroupViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\Select\OptionViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\SubmitViewHelper;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\UploadViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\FormViewHelper as HeadlessFormViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\TextfieldViewHelper as HeadlessTextfieldViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\TextareaViewHelper as HeadlessTextareaViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\ButtonViewHelper as HeadlessButtonViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\CheckboxViewHelper as HeadlessCheckboxViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\CountrySelectViewHelper as HeadlessCountrySelectViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\HiddenViewHelper as HeadlessHiddenViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\PasswordViewHelper as HeadlessPasswordViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\RadioViewHelper as HeadlessRadioViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\SelectViewHelper as HeadlessSelectViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\Select\OptgroupViewHelper as HeadlessOptgroupViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\Select\OptionViewHelper as HeadlessOptionViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\SubmitViewHelper as HeadlessSubmitViewHelper;
+use FriendsOfTYPO3\Headless\XClass\ViewHelpers\Form\UploadViewHelper as HeadlessUploadViewHelper;
 
 defined('TYPO3') || die();
 
@@ -43,6 +71,64 @@ call_user_func(
         ];
 
         $features = GeneralUtility::makeInstance(Features::class);
+
+        if (ExtensionManagementUtility::isLoaded('fluid')) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][FormViewHelper::class] = [
+                'className' => HeadlessFormViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TextfieldViewHelper::class] = [
+                'className' => HeadlessTextfieldViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TextareaViewHelper::class] = [
+                'className' => HeadlessTextareaViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][ButtonViewHelper::class] = [
+                'className' => HeadlessButtonViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][CheckboxViewHelper::class] = [
+                'className' => HeadlessCheckboxViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][CountrySelectViewHelper::class] = [
+                'className' => HeadlessCountrySelectViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][HiddenViewHelper::class] = [
+                'className' => HeadlessHiddenViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][PasswordViewHelper::class] = [
+                'className' => HeadlessPasswordViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][RadioViewHelper::class] = [
+                'className' => HeadlessRadioViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][SelectViewHelper::class] = [
+                'className' => HeadlessSelectViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][OptgroupViewHelper::class] = [
+                'className' => HeadlessOptgroupViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][OptionViewHelper::class] = [
+                'className' => HeadlessOptionViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][SubmitViewHelper::class] = [
+                'className' => HeadlessSubmitViewHelper::class
+            ];
+
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][UploadViewHelper::class] = [
+                'className' => HeadlessUploadViewHelper::class
+            ];
+        }
 
         if ($features->isFeatureEnabled('headless.storageProxy')) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][LocalDriver::class] = [


### PR DESCRIPTION
This pull request adds the basic support for f:form.* viewhelpers to render JSON. It can be used like that:

**Template**
```html
<f:spaceless>
    <f:format.raw>
        <f:format.json value="{
            form: '{f:render(partial: \'Form\', arguments: \'{_all}\') -> headless:format.json.decode()}'
        }"/>
    </f:format.raw>
</f:spaceless>
```

**Partial**
```html
<f:form additionalAttributes="{data-anything: 'some info', data-something: 'blub'}" class="bla" action="submit" name="customer">
    <f:form.textfield name="myTextBox" value="default value" />
</f:form>
```

The form viewhelpers return a JSON string.