### PR TITLE
[BUGFIX] Add missing use statement for HeadlessModeInterface 

### DIFF
--- a/Classes/XClass/Controller/PreviewController.php
+++ b/Classes/XClass/Controller/PreviewController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Headless\XClass\Controller;
 
+use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface;
 use FriendsOfTYPO3\Headless\Utility\UrlUtility;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;


### PR DESCRIPTION
If you're using for example workspaces and try to preview jour change you will get the following exception.

  Class "FriendsOfTYPO3\Headless\XClass\Controller\HeadlessModeInterface" not found

This applies also to the Core Preview Module.