### PR TITLE
Add use HeadlessModeInterface

### DIFF
--- a/Classes/XClass/Preview/PreviewUriBuilder.php
+++ b/Classes/XClass/Preview/PreviewUriBuilder.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Core\Routing\InvalidRouteArgumentsException;
 use TYPO3\CMS\Core\Routing\UnableToLinkToPageException;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface;
+
 
 /**
  * @codeCoverageIgnore


### PR DESCRIPTION
Added missing "use FriendsOfTYPO3\Headless\Utility\HeadlessModeInterface", causing Error when trying to access the workspace preview.