### PR TITLE
[BUGFIX] Return file extension for processed files

### DIFF
--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -153,7 +153,7 @@ class FileUtility
             ],
             'crop' => $crop,
             'autoplay' => $fileReference->getProperty('autoplay'),
-            'extension' => $fileReference->getProperty('extension'),
+            'extension' => $fileReference->getExtension() ?: null,
         ];
 
         $processedProperties = array_merge(

--- a/Tests/Unit/Utility/FileUtilityTest.php
+++ b/Tests/Unit/Utility/FileUtilityTest.php
@@ -623,10 +623,11 @@ class FileUtilityTest extends UnitTestCase
     {
         $processedFile = $this->createPartialMock(
             ProcessedFile::class,
-            ['getProperty', 'getMimeType', 'getSize', 'hasProperty', 'getPublicUrl']
+            ['getProperty', 'getMimeType', 'getSize', 'hasProperty', 'getPublicUrl', 'getExtension']
         );
         $processedFile->method('getMimeType')->willReturn('image/jpeg');
         $processedFile->method('getSize')->willReturn($data['size']);
+        $processedFile->method('getExtension')->willReturn((string)($data['extension'] ?? ''));
         $processedFile->method('getProperty')->willReturnCallback(static function ($key) use ($data) {
             return $data[$key] ?? null;
         });
@@ -762,7 +763,7 @@ class FileUtilityTest extends UnitTestCase
                         ],
                     'crop' => '{"default":{"cropArea":{"x":0,"y":0,"width":1,"height":1},"selectedRatio":"NaN","focusArea":null}}',
                     'autoplay' => 0,
-                    'extension' => 'jpg',
+                    'extension' => null,
                 ],
         ];
     }


### PR DESCRIPTION
## Summary
- After image processing, `FileUtility` reads `extension` via `getProperty('extension')` on a `ProcessedFile`.
- Processed files do not store an `extension` property, so JSON always contains `"extension": null` whenever processing actually runs (`maxWidth`, crop, etc.).
- Use `getExtension()` instead (already used elsewhere in `FileUtility` for `imagefile_ext` checks), which derives the extension from the filename of the served file.

## Example
With `processingConfiguration.maxWidth = 1200` on `ogImage`, properties previously looked like:
```json
"extension": null
```
and now correctly return:
```json
"extension": "jpg"
```

## Test plan
- [ ] Process an image via `FilesProcessor` with `maxWidth` / crop enabled
- [ ] Confirm `properties.extension` matches the processed file (e.g. `jpg`, or `webp` when `fileExtension = webp`)
- [ ] Confirm unprocessed / unchanged files still return a correct extension